### PR TITLE
Set up server Supabase utilities and providers

### DIFF
--- a/app/(dashboard)/albums/[slug]/page.tsx
+++ b/app/(dashboard)/albums/[slug]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { getServerClient } from '@/lib/supabaseServer';
+
+interface AlbumPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+const VISIBILITY_LABEL: Record<'public' | 'unlisted' | 'private', string> = {
+  public: 'Public',
+  unlisted: 'Unlisted',
+  private: 'Private',
+};
+
+export default async function AlbumPage({ params }: AlbumPageProps) {
+  const supabase = getServerClient();
+  const { data: album, error } = await supabase
+    .from('albums')
+    .select('id, name, visibility')
+    .eq('slug', params.slug)
+    .maybeSingle();
+
+  if (error) {
+    if (error.status === 404 || error.status === 406 || error.code === '42501') {
+      notFound();
+    }
+
+    throw error;
+  }
+
+  if (!album) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-10 pb-16">
+      <header className="flex flex-col gap-4 rounded-3xl border border-border bg-card p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{album.name}</h1>
+            <Badge variant="secondary" className="rounded-full">
+              {VISIBILITY_LABEL[album.visibility]}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">Album management tools will appear here soon.</p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Button variant="outline" className="rounded-full" type="button">
+            Share
+          </Button>
+          <Button className="rounded-full" type="button">
+            Edit
+          </Button>
+        </div>
+      </header>
+
+      <Tabs defaultValue="stickers" className="space-y-6">
+        <TabsList className="w-full justify-start gap-2 overflow-x-auto rounded-full bg-muted/60 p-1">
+          <TabsTrigger value="stickers" className="rounded-full px-4 py-2">
+            Stickers
+          </TabsTrigger>
+          <TabsTrigger value="pack" className="rounded-full px-4 py-2">
+            Pack
+          </TabsTrigger>
+          <TabsTrigger value="share" className="rounded-full px-4 py-2">
+            Share
+          </TabsTrigger>
+          <TabsTrigger value="settings" className="rounded-full px-4 py-2">
+            Settings
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="stickers" className="focus-visible:outline-none">
+          <PlaceholderPanel label="Stickers tools coming soon." />
+        </TabsContent>
+        <TabsContent value="pack" className="focus-visible:outline-none">
+          <PlaceholderPanel label="Pack builder will be available shortly." />
+        </TabsContent>
+        <TabsContent value="share" className="focus-visible:outline-none">
+          <PlaceholderPanel label="Share options will appear here." />
+        </TabsContent>
+        <TabsContent value="settings" className="focus-visible:outline-none">
+          <PlaceholderPanel label="Album settings form coming soon." />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function PlaceholderPanel({ label }: { label: string }) {
+  return (
+    <div className="rounded-3xl border border-dashed border-muted-foreground/30 bg-card/40 p-10 text-center text-sm text-muted-foreground">
+      <Suspense fallback={null}>{label}</Suspense>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/_components/dashboard-shell.tsx
+++ b/app/(dashboard)/dashboard/_components/dashboard-shell.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Suspense, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { NavBar } from '@/components/NavBar';
-import { Skeleton } from '@/components/ui/skeleton';
+import { AlbumGrid } from '@/components/AlbumGrid';
 
 type DashboardShellProps = {
   userLabel?: string | null;
@@ -18,23 +18,9 @@ export function DashboardShell({ userLabel }: DashboardShellProps) {
       <NavBar searchValue={searchValue} onSearchChange={setSearchValue} userLabel={normalizedLabel} />
       <main className="flex-1">
         <div className="mx-auto max-w-6xl px-4 py-10">
-          <Suspense fallback={<AlbumGridSkeleton />}>
-            <div className="rounded-3xl border border-dashed border-border bg-card/40 px-6 py-20 text-center text-muted-foreground">
-              Album grid coming soon.
-            </div>
-          </Suspense>
+          <AlbumGrid search={searchValue} />
         </div>
       </main>
-    </div>
-  );
-}
-
-function AlbumGridSkeleton() {
-  return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <Skeleton key={index} className="h-40 w-full rounded-3xl" />
-      ))}
     </div>
   );
 }

--- a/app/(dashboard)/dashboard/_components/dashboard-shell.tsx
+++ b/app/(dashboard)/dashboard/_components/dashboard-shell.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Suspense, useMemo, useState } from 'react';
+
+import { NavBar } from '@/components/NavBar';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type DashboardShellProps = {
+  userLabel?: string | null;
+};
+
+export function DashboardShell({ userLabel }: DashboardShellProps) {
+  const [searchValue, setSearchValue] = useState('');
+  const normalizedLabel = useMemo(() => userLabel?.trim() || undefined, [userLabel]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-muted/20">
+      <NavBar searchValue={searchValue} onSearchChange={setSearchValue} userLabel={normalizedLabel} />
+      <main className="flex-1">
+        <div className="mx-auto max-w-6xl px-4 py-10">
+          <Suspense fallback={<AlbumGridSkeleton />}>
+            <div className="rounded-3xl border border-dashed border-border bg-card/40 px-6 py-20 text-center text-muted-foreground">
+              Album grid coming soon.
+            </div>
+          </Suspense>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function AlbumGridSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Skeleton key={index} className="h-40 w-full rounded-3xl" />
+      ))}
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,10 +1,23 @@
 import { redirect } from 'next/navigation';
-import { getSupabaseServerClient } from '@/lib/supabaseServer';
+
+import Providers from '@/components/Providers';
+import { DashboardShell } from './_components/dashboard-shell';
+import { getServerUser } from '@/lib/supabaseServer';
 
 export default async function DashboardPage() {
-  const supabase = getSupabaseServerClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
+  const { user } = await getServerUser();
 
-  return <div className="p-6">Halo, {user.email}</div>;
+  if (!user) {
+    redirect('/login');
+  }
+
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+  const fullName = typeof metadata.full_name === 'string' ? metadata.full_name : undefined;
+  const displayLabel = fullName && fullName.trim().length > 0 ? fullName : user.email ?? user.phone ?? undefined;
+
+  return (
+    <Providers>
+      <DashboardShell userLabel={displayLabel} />
+    </Providers>
+  );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,12 +1,5 @@
-import { NavBar } from '@/components/NavBar';
+import type { ReactNode } from 'react';
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex min-h-screen flex-col">
-      <NavBar />
-      <main className="flex-1 bg-muted/20">
-        <div className="mx-auto max-w-6xl px-4 py-10">{children}</div>
-      </main>
-    </div>
-  );
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
 }

--- a/app/(public)/p/[slug]/page.tsx
+++ b/app/(public)/p/[slug]/page.tsx
@@ -1,0 +1,202 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { ShareButtons } from '@/components/ShareButtons';
+import { QRCodeCard } from '@/components/QRCodeCard';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { getServerClient } from '@/lib/supabaseServer';
+import { formatCount } from '@/lib/utils';
+
+interface PublicAlbumPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+type AlbumRow = {
+  id: string;
+  name: string;
+  slug: string;
+  visibility: 'public' | 'unlisted' | 'private';
+  updated_at: string | null;
+};
+
+type StickerRow = {
+  id: string;
+  file_url: string | null;
+  thumb_url: string | null;
+  title: string | null;
+  sort_index: number | null;
+};
+
+type PackRow = {
+  id: string;
+  name: string;
+  exported_zip_url: string | null;
+  public_url: string | null;
+  wa_share_url: string | null;
+  created_at: string | null;
+};
+
+const VISIBILITY_BADGE: Record<'public' | 'unlisted' | 'private', string> = {
+  public: 'Public',
+  unlisted: 'Unlisted',
+  private: 'Private',
+};
+
+export default async function PublicAlbumPage({ params }: PublicAlbumPageProps) {
+  const supabase = getServerClient();
+  const { data: album, error: albumError } = await (supabase.from('albums') as any)
+    .select('id, name, slug, visibility, updated_at')
+    .eq('slug', params.slug)
+    .maybeSingle();
+
+  if (albumError) {
+    if (albumError.code === 'PGRST116' || albumError.status === 406 || albumError.status === 404) {
+      notFound();
+    }
+
+    throw albumError;
+  }
+
+  const albumData = album as AlbumRow | null;
+  if (!albumData || !['public', 'unlisted'].includes(albumData.visibility)) {
+    notFound();
+  }
+
+  const { data: stickersData, error: stickersError } = await (supabase.from('stickers') as any)
+    .select('id, file_url, thumb_url, title, sort_index')
+    .eq('album_id', albumData.id)
+    .order('sort_index', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (stickersError) {
+    throw stickersError;
+  }
+
+  const stickers = (stickersData as StickerRow[] | null) ?? [];
+
+  const { data: packData, error: packError } = await (supabase.from('packs') as any)
+    .select('id, name, exported_zip_url, public_url, wa_share_url, created_at')
+    .eq('album_id', albumData.id)
+    .not('exported_zip_url', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (packError && packError.code !== 'PGRST116' && packError.status !== 406) {
+    throw packError;
+  }
+
+  const latestPack = packData && (packData as PackRow).exported_zip_url ? (packData as PackRow) : null;
+
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+  const publicUrl = `${siteUrl}/p/${albumData.slug}`;
+  const updatedAt = albumData.updated_at ? new Date(albumData.updated_at) : null;
+  const formattedUpdatedAt = updatedAt && !Number.isNaN(updatedAt.getTime())
+    ? new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(updatedAt)
+    : null;
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-4 py-10 sm:px-6 lg:px-8">
+      <header className="space-y-6 rounded-3xl border border-border/80 bg-card/80 p-8 shadow-sm">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{albumData.name}</h1>
+              <Badge variant="secondary" className="rounded-full">
+                {VISIBILITY_BADGE[albumData.visibility]}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {formatCount(stickers.length)} stickers ·{' '}
+              {formattedUpdatedAt ? `Updated ${formattedUpdatedAt}` : 'Recently updated'}
+            </p>
+          </div>
+          {latestPack?.exported_zip_url ? (
+            <Button asChild size="lg" className="rounded-full px-6">
+              <Link href={latestPack.exported_zip_url} target="_blank" rel="noopener noreferrer">
+                Download latest pack
+              </Link>
+            </Button>
+          ) : (
+            <div className="rounded-full border border-dashed border-muted-foreground/40 px-4 py-2 text-sm text-muted-foreground">
+              Pack export coming soon
+            </div>
+          )}
+        </div>
+        <div className="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <ShareButtons publicUrl={publicUrl} waUrl={latestPack?.wa_share_url ?? undefined} />
+          <QRCodeCard url={publicUrl} />
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold">Sticker preview</h2>
+          <span className="text-sm text-muted-foreground">Read-only view</span>
+        </div>
+        {stickers.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {stickers.map((sticker) => (
+              <Card key={sticker.id} className="overflow-hidden rounded-3xl border border-border/70 bg-card/70 shadow-sm">
+                <div className="relative aspect-square bg-muted">
+                  {sticker.thumb_url || sticker.file_url ? (
+                    <Image
+                      src={(sticker.thumb_url ?? sticker.file_url) as string}
+                      alt={sticker.title ?? 'Sticker preview'}
+                      fill
+                      sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center bg-muted text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      No preview
+                    </div>
+                  )}
+                </div>
+                {(sticker.title ?? '').trim() && (
+                  <CardContent className="p-4">
+                    <p className="truncate text-sm font-medium">{sticker.title}</p>
+                  </CardContent>
+                )}
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-3xl border border-dashed border-muted-foreground/30 bg-card/60 p-12 text-center">
+            <p className="text-sm text-muted-foreground">No stickers published yet.</p>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-3xl border border-border/70 bg-card/70 p-8 shadow-sm">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Download pack</h2>
+          {latestPack?.exported_zip_url ? (
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">{latestPack.name || 'Sticker pack'}</p>
+                {latestPack.created_at && (
+                  <p>Exported on {new Date(latestPack.created_at).toLocaleString()}</p>
+                )}
+              </div>
+              <Button asChild size="lg" className="rounded-full px-6">
+                <Link href={latestPack.exported_zip_url} target="_blank" rel="noopener noreferrer">
+                  Download ZIP
+                </Link>
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Once the owner exports a pack, a download link will appear here.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/api/albums/[id]/route.ts
+++ b/app/api/albums/[id]/route.ts
@@ -1,48 +1,180 @@
-import { NextResponse } from 'next/server';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
-import { albumUpdateSchema } from '@/lib/zod-schemas';
-import { slugify } from '@/lib/slug';
-import type { Database } from '@/types/database';
+import { NextRequest, NextResponse } from 'next/server';
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
 
-export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
-  const { data, error } = await supabase.from('albums').select('*').eq('id', params.id).single();
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 404 });
+import { getServerClient } from '@/lib/supabaseServer';
+import { slugify } from '@/lib/slug';
+
+const updateAlbumSchema = z
+  .object({
+    name: z.string().trim().min(1, 'Name is required').max(120, 'Name is too long').optional(),
+    visibility: z.union([z.literal('public'), z.literal('unlisted'), z.literal('private')]).optional(),
+  })
+  .refine((value) => value.name || value.visibility, {
+    message: 'At least one field must be provided',
+  });
+
+type AlbumRow = {
+  id: string;
+  owner_id: string;
+  name: string;
+  slug: string;
+  visibility: 'public' | 'unlisted' | 'private';
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = getServerClient();
+  const client = supabase as unknown as SupabaseClient<any>;
+  const body = await request.json().catch(() => ({}));
+  const parsed = updateAlbumSchema.safeParse(body ?? {});
+
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? 'Invalid payload' }, { status: 400 });
   }
-  return NextResponse.json(data);
+
+  const albumId = params.id;
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: existingAlbum, error: existingError } = (await client
+    .from('albums')
+    .select('id, owner_id, name, slug, visibility, created_at, updated_at')
+    .eq('id', albumId)
+    .maybeSingle()) as { data: AlbumRow | null; error: PostgrestError | null };
+
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+
+  if (!existingAlbum) {
+    return NextResponse.json({ error: 'Album not found' }, { status: 404 });
+  }
+
+  const updatePayload: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (parsed.data.name) {
+    updatePayload.name = parsed.data.name;
+    const newSlugBase = slugify(parsed.data.name);
+    if (newSlugBase.length > 0) {
+      const uniqueSlug = await ensureUniqueSlug(client, newSlugBase, albumId);
+      updatePayload.slug = uniqueSlug;
+    }
+  }
+
+  if (parsed.data.visibility) {
+    updatePayload.visibility = parsed.data.visibility;
+  }
+
+  const { data, error } = (await client
+    .from('albums')
+    .update(updatePayload as Record<string, unknown>)
+    .eq('id', albumId)
+    .select('id, name, slug, visibility, updated_at, created_at')
+    .maybeSingle()) as {
+    data: { id: string; name: string; slug: string; visibility: AlbumRow['visibility']; updated_at: string | null; created_at: string | null } | null;
+    error: PostgrestError | null;
+  };
+
+  if (error) {
+    const status = error.code === 'PGRST302' ? 403 : 500;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'Failed to update album' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    id: data.id,
+    name: data.name,
+    slug: data.slug,
+    visibility: data.visibility,
+    updatedAt: data.updated_at ?? data.created_at ?? new Date().toISOString(),
+  });
 }
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
-  const body = await request.json();
-  const parsed = albumUpdateSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = getServerClient();
+  const client = supabase as unknown as SupabaseClient<any>;
+  const albumId = params.id;
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
   }
 
-  const payload: Record<string, unknown> = { ...parsed.data };
-  if (parsed.data.name) {
-    payload.slug = slugify(parsed.data.name);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { data, error } = await supabase
+  const { data: album, error: albumError } = (await client
     .from('albums')
-    .update(payload)
-    .eq('id', params.id)
-    .select()
-    .single();
+    .select('id, owner_id, name, slug, visibility, created_at, updated_at')
+    .eq('id', albumId)
+    .maybeSingle()) as { data: AlbumRow | null; error: PostgrestError | null };
+
+  if (albumError) {
+    return NextResponse.json({ error: albumError.message }, { status: 500 });
+  }
+
+  if (!album) {
+    return NextResponse.json({ error: 'Album not found' }, { status: 404 });
+  }
+
+  if (album.owner_id !== user.id) {
+    return NextResponse.json({ error: 'Only the owner can delete this album' }, { status: 403 });
+  }
+
+  const { error } = await client.from('albums').delete().eq('id', albumId);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json(data);
+  return NextResponse.json({ success: true });
+}
+
+async function ensureUniqueSlug(client: SupabaseClient<any>, baseSlug: string, currentId?: string) {
+  let candidate = baseSlug;
+  let suffix = 1;
+
+  while (true) {
+    const { data, error } = await client
+      .from('albums')
+      .select('id')
+      .eq('slug', candidate)
+      .limit(1)
+      .maybeSingle();
+
+    if (error && error.code !== 'PGRST116') {
+      throw new Error(error.message);
+    }
+
+    if (!data || data.id === currentId) {
+      return candidate;
+    }
+
+    candidate = `${baseSlug}-${suffix}`;
+    suffix += 1;
+  }
 }

--- a/app/api/albums/[id]/stickers/route.ts
+++ b/app/api/albums/[id]/stickers/route.ts
@@ -1,52 +1,342 @@
-// app/api/albums/[id]/stickers/route.ts
+import { randomUUID } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServerClient } from '@/lib/supabaseServer';
+import { z } from 'zod';
 
-type AlbumRow = { id: string; owner_id: string };
-type CollaboratorRow = { id: string };
+import { getServerClient, type SupabaseServerClient } from '@/lib/supabaseServer';
 
-async function canWriteAlbum(userId: string, albumId: string) {
-  const supabase = getSupabaseServerClient();
+const ACCEPTED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
 
-  // Ambil owner album dengan maybeSingle, lalu cek null/error
-  const albumRes = await supabase
-    .from('albums')
+const reorderSchema = z.object({
+  orders: z
+    .array(
+      z.object({
+        id: z.string().uuid('Sticker id tidak valid'),
+        sort_index: z.number().int().min(0, 'Index harus positif'),
+      }),
+    )
+    .min(1, 'Minimal satu sticker untuk diurutkan'),
+});
+
+const deleteSchema = z.object({
+  ids: z.array(z.string().uuid('Sticker id tidak valid')).min(1, 'Minimal satu sticker untuk dihapus'),
+});
+
+type AlbumRow = {
+  id: string;
+  owner_id: string;
+};
+
+type StickerRow = {
+  id: string;
+  file_url: string;
+  thumb_url: string | null;
+  title: string | null;
+  size_kb: number | null;
+  sort_index: number;
+  created_at: string | null;
+};
+
+async function fetchAlbum(
+  supabase: SupabaseServerClient,
+  albumId: string,
+): Promise<AlbumRow | null> {
+  const { data, error } = await (supabase.from('albums') as any)
     .select('id, owner_id')
     .eq('id', albumId)
     .maybeSingle();
 
-  if (albumRes.error) return false;
-  const album = albumRes.data as AlbumRow | null;
-  if (!album) return false;
-  if (album.owner_id === userId) return true;
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
 
-  // Cek kolaborator
-  const collabRes = await supabase
-    .from('album_collaborators')
+  return (data as AlbumRow | null) ?? null;
+}
+
+async function canWriteAlbum(
+  supabase: SupabaseServerClient,
+  userId: string,
+  albumId: string,
+): Promise<boolean> {
+  const album = await fetchAlbum(supabase, albumId);
+  if (!album) {
+    return false;
+  }
+  if (album.owner_id === userId) {
+    return true;
+  }
+
+  const { data, error } = await (supabase.from('album_collaborators') as any)
     .select('id')
     .eq('album_id', albumId)
     .eq('user_id', userId)
     .maybeSingle();
 
-  if (collabRes.error) return false;
-  const collaborator = collabRes.data as CollaboratorRow | null;
-  return !!collaborator;
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return false;
+    }
+    throw error;
+  }
+
+  return Boolean(data);
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const supabase = getSupabaseServerClient();
+function getExtension(file: File): string {
+  if (file.type === 'image/png') return 'png';
+  if (file.type === 'image/webp') return 'webp';
+  if (file.type === 'image/jpeg') return 'jpg';
+  const nameParts = file.name.split('.');
+  return nameParts.length > 1 ? nameParts.pop()!.toLowerCase() : 'png';
+}
+
+async function touchAlbum(supabase: SupabaseServerClient, albumId: string) {
+  await (supabase.from('albums') as any)
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', albumId);
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const supabase = getServerClient();
+  const albumId = params.id;
 
   const {
     data: { user },
+    error: userError,
   } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const album = await fetchAlbum(supabase, albumId);
+  if (!album) {
+    return NextResponse.json({ error: 'Album tidak ditemukan' }, { status: 404 });
+  }
+
+  const { data, error } = await (supabase.from('stickers') as any)
+    .select('id, file_url, thumb_url, title, size_kb, sort_index, created_at')
+    .eq('album_id', albumId)
+    .order('sort_index', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json<{ data: StickerRow[] }>({ data: (data as StickerRow[]) ?? [] });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const supabase = getServerClient();
   const albumId = params.id;
-  const allowed = await canWriteAlbum(user.id, albumId);
-  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  // TODO: ambil payload dan buat sticker di sini
-  const payload = await req.json();
-  // contoh respons sementara
-  return NextResponse.json({ ok: true, received: payload });
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const writable = await canWriteAlbum(supabase, user.id, albumId);
+  if (!writable) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+  const files = formData
+    .getAll('files')
+    .filter((value): value is File => value instanceof File && value.size > 0);
+
+  if (files.length === 0) {
+    return NextResponse.json({ error: 'Tidak ada file yang diunggah' }, { status: 400 });
+  }
+
+  for (const file of files) {
+    if (!ACCEPTED_MIME_TYPES.has(file.type)) {
+      return NextResponse.json({ error: `Tipe file tidak didukung: ${file.type}` }, { status: 400 });
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json({ error: `${file.name} melebihi batas ukuran 2MB` }, { status: 400 });
+    }
+  }
+
+  const { data: maxSortRow, error: maxSortError } = await (supabase.from('stickers') as any)
+    .select('sort_index')
+    .eq('album_id', albumId)
+    .order('sort_index', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (maxSortError && maxSortError.code !== 'PGRST116') {
+    return NextResponse.json({ error: maxSortError.message }, { status: 500 });
+  }
+
+  let lastSortIndex = (maxSortRow as { sort_index: number } | null)?.sort_index ?? -1;
+  const insertPayload: Array<{
+    album_id: string;
+    owner_id: string;
+    file_url: string;
+    thumb_url: string | null;
+    title: string | null;
+    size_kb: number | null;
+    sort_index: number;
+  }> = [];
+
+  for (const file of files) {
+    const extension = getExtension(file);
+    const path = `${albumId}/${user.id}/${randomUUID()}.${extension}`;
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const { error: uploadError } = await supabase.storage
+      .from('stickers')
+      .upload(path, buffer, {
+        cacheControl: '3600',
+        contentType: file.type,
+        upsert: false,
+      });
+
+    if (uploadError) {
+      return NextResponse.json({ error: uploadError.message }, { status: 500 });
+    }
+
+    const { data: publicUrlData } = supabase.storage.from('stickers').getPublicUrl(path);
+    const publicUrl = publicUrlData.publicUrl;
+
+    lastSortIndex += 1;
+    insertPayload.push({
+      album_id: albumId,
+      owner_id: user.id,
+      file_url: publicUrl,
+      thumb_url: publicUrl,
+      title: file.name.replace(/\.[^/.]+$/, '') || null,
+      size_kb: Math.max(1, Math.round(file.size / 1024)),
+      sort_index: lastSortIndex,
+    });
+  }
+
+  const { data: inserted, error: insertError } = await (supabase.from('stickers') as any)
+    .insert(insertPayload)
+    .select('id, file_url, thumb_url, title, size_kb, sort_index, created_at');
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  await touchAlbum(supabase, albumId);
+
+  return NextResponse.json({ data: inserted ?? [] });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const supabase = getServerClient();
+  const albumId = params.id;
+
+  const body = await req.json().catch(() => null);
+  const parsed = reorderSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const writable = await canWriteAlbum(supabase, user.id, albumId);
+  if (!writable) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  for (const order of parsed.data.orders) {
+    const { error } = await (supabase.from('stickers') as any)
+      .update({ sort_index: order.sort_index })
+      .eq('id', order.id)
+      .eq('album_id', albumId);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+  }
+
+  await touchAlbum(supabase, albumId);
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const supabase = getServerClient();
+  const albumId = params.id;
+
+  const body = await req.json().catch(() => null);
+  const parsed = deleteSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const writable = await canWriteAlbum(supabase, user.id, albumId);
+  if (!writable) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { error } = await (supabase.from('stickers') as any)
+    .delete()
+    .eq('album_id', albumId)
+    .in('id', parsed.data.ids);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await touchAlbum(supabase, albumId);
+
+  return NextResponse.json({ ok: true });
 }

--- a/app/api/albums/route.ts
+++ b/app/api/albums/route.ts
@@ -1,66 +1,287 @@
-import { NextResponse } from 'next/server';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
-import { albumCreateSchema } from '@/lib/zod-schemas';
-import { slugify } from '@/lib/slug';
-import type { Database } from '@/types/database';
+import { NextRequest, NextResponse } from 'next/server';
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
 
-export async function GET() {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+import { getServerClient, type SupabaseServerClient } from '@/lib/supabaseServer';
+import { slugify } from '@/lib/slug';
+
+const createAlbumSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(120, 'Name is too long'),
+  visibility: z.union([z.literal('public'), z.literal('unlisted'), z.literal('private')]).default('private').optional(),
+});
+
+const scopeSchema = z.union([z.literal('all'), z.literal('owned'), z.literal('shared')]);
+
+type AlbumRow = {
+  id: string;
+  owner_id: string;
+  name: string;
+  slug: string;
+  visibility: 'public' | 'unlisted' | 'private';
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type StickerRow = {
+  thumb_url: string | null;
+  file_url: string | null;
+};
+
+type ListResponse = {
+  data: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    visibility: 'public' | 'unlisted' | 'private';
+    updatedAt: string;
+    stickersCount: number;
+    thumbnails: string[];
+  }>;
+};
+
+export async function GET(request: NextRequest) {
+  const supabase = getServerClient();
+  const url = new URL(request.url);
+  const scopeParam = url.searchParams.get('scope');
+  const searchQuery = url.searchParams.get('q')?.trim() ?? '';
+  const scopeResult = scopeSchema.safeParse(scopeParam);
+  const scope = scopeResult.success ? scopeResult.data : 'all';
+
   const {
-    data: { user }
+    data: { user },
+    error: userError,
   } = await supabase.auth.getUser();
 
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
   if (!user) {
-    return NextResponse.json({ data: [] });
+    return NextResponse.json<ListResponse>({ data: [] });
   }
 
-  const { data, error } = await supabase
-    .from('albums')
-    .select('*')
-    .eq('owner_id', user.id)
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  const ownedAlbums = await fetchOwnedAlbums(supabase, user.id, searchQuery);
+  if (ownedAlbums.error) {
+    return NextResponse.json({ error: ownedAlbums.error }, { status: 500 });
   }
 
-  return NextResponse.json({ data });
+  const sharedAlbums = await fetchSharedAlbums(supabase, user.id, searchQuery);
+  if (sharedAlbums.error) {
+    return NextResponse.json({ error: sharedAlbums.error }, { status: 500 });
+  }
+
+  let albums: AlbumRow[] = [];
+  if (scope === 'owned') {
+    albums = ownedAlbums.albums;
+  } else if (scope === 'shared') {
+    albums = sharedAlbums.albums;
+  } else {
+    const merged = new Map<string, AlbumRow>();
+    ownedAlbums.albums.forEach((album) => {
+      merged.set(album.id, album);
+    });
+    sharedAlbums.albums.forEach((album) => {
+      merged.set(album.id, album);
+    });
+    albums = Array.from(merged.values()).sort((a, b) => {
+      const aTime = new Date(a.updated_at ?? a.created_at ?? 0).getTime();
+      const bTime = new Date(b.updated_at ?? b.created_at ?? 0).getTime();
+      return bTime - aTime;
+    });
+  }
+
+  const detailedAlbums = await Promise.all(
+    albums.map(async (album) => {
+      const stats = await fetchAlbumStats(supabase, album.id);
+      if (stats.error) {
+        return {
+          id: album.id,
+          name: album.name,
+          slug: album.slug,
+          visibility: album.visibility,
+          updatedAt: album.updated_at ?? album.created_at ?? new Date().toISOString(),
+          stickersCount: 0,
+          thumbnails: [],
+        };
+      }
+
+      return {
+        id: album.id,
+        name: album.name,
+        slug: album.slug,
+        visibility: album.visibility,
+        updatedAt: album.updated_at ?? album.created_at ?? new Date().toISOString(),
+        stickersCount: stats.count,
+        thumbnails: stats.thumbnails,
+      };
+    }),
+  );
+
+  return NextResponse.json<ListResponse>({ data: detailedAlbums });
 }
 
-export async function POST(request: Request) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
-  const body = await request.json();
-  const parsed = albumCreateSchema.safeParse(body);
+export async function POST(request: NextRequest) {
+  const supabase = getServerClient();
+  const client = supabase as unknown as SupabaseClient<any>;
+  const body = await request.json().catch(() => null);
+  const parsed = createAlbumSchema.safeParse(body ?? {});
+
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }
 
   const {
-    data: { user }
+    data: { user },
+    error: userError,
   } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const slug = slugify(parsed.data.name);
+  const baseSlug = slugify(parsed.data.name) || `album-${Math.random().toString(36).slice(2, 8)}`;
+  const slug = await ensureUniqueSlug(client, baseSlug);
 
-  const { data, error } = await supabase
-    .from('albums')
-    .insert({
-      name: parsed.data.name,
-      visibility: parsed.data.visibility ?? 'public',
-      cover_url: parsed.data.coverUrl ?? null,
-      owner_id: user.id,
-      slug
-    })
-    .select()
-    .single();
+  const albumsTable = client.from('albums') as any;
+  const { data, error } = (await albumsTable
+    .insert([
+      {
+        owner_id: user.id,
+        name: parsed.data.name,
+        visibility: parsed.data.visibility ?? 'private',
+        slug,
+        updated_at: new Date().toISOString(),
+      },
+    ])
+    .select('id, name, slug, visibility, updated_at, created_at')
+    .single()) as {
+    data: { id: string; name: string; slug: string; visibility: AlbumRow['visibility']; updated_at: string | null; created_at: string | null } | null;
+    error: PostgrestError | null;
+  };
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json(data, { status: 201 });
+  if (!data) {
+    return NextResponse.json({ error: 'Failed to create album' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    id: data.id,
+    name: data.name,
+    slug: data.slug,
+    visibility: data.visibility,
+    updatedAt: data.updated_at ?? data.created_at ?? new Date().toISOString(),
+  });
+}
+
+async function ensureUniqueSlug(client: SupabaseClient<any>, baseSlug: string) {
+  let candidate = baseSlug;
+  let suffix = 1;
+
+  while (true) {
+    const { data, error } = await client.from('albums').select('id').eq('slug', candidate).limit(1).maybeSingle();
+    if (error && error.code !== 'PGRST116') {
+      throw new Error(error.message);
+    }
+    if (!data) {
+      return candidate;
+    }
+    candidate = `${baseSlug}-${suffix}`;
+    suffix += 1;
+  }
+}
+
+async function fetchAlbumStats(client: SupabaseServerClient, albumId: string) {
+  const supabase = client as unknown as SupabaseClient<any>;
+  const thumbnailsResponse = (await supabase
+    .from('stickers')
+    .select('thumb_url, file_url')
+    .eq('album_id', albumId)
+    .order('sort_index', { ascending: true, nullsFirst: false })
+    .limit(6)) as { data: StickerRow[] | null; error: PostgrestError | null };
+
+  if (thumbnailsResponse.error) {
+    return { error: thumbnailsResponse.error.message, thumbnails: [], count: 0 };
+  }
+
+  const countResponse = (await supabase
+    .from('stickers')
+    .select('id', { head: true, count: 'exact' })
+    .eq('album_id', albumId)) as { error: PostgrestError | null; count: number | null };
+
+  if (countResponse.error) {
+    return { error: countResponse.error.message, thumbnails: [], count: 0 };
+  }
+
+  const thumbnails = (thumbnailsResponse.data ?? [])
+    .map((item) => item.thumb_url ?? item.file_url)
+    .filter((item): item is string => typeof item === 'string' && item.length > 0);
+
+  return {
+    error: null,
+    thumbnails,
+    count: countResponse.count ?? thumbnails.length,
+  };
+}
+
+async function fetchOwnedAlbums(client: SupabaseServerClient, ownerId: string, search: string) {
+  const supabase = client as unknown as SupabaseClient<any>;
+  let query = supabase
+    .from('albums')
+    .select('id, owner_id, name, slug, visibility, created_at, updated_at')
+    .eq('owner_id', ownerId)
+    .order('updated_at', { ascending: false, nullsFirst: false });
+
+  if (search) {
+    query = query.ilike('name', `%${search}%`);
+  }
+
+  const { data, error } = (await query) as { data: AlbumRow[] | null; error: PostgrestError | null };
+
+  if (error) {
+    return { albums: [] as AlbumRow[], error: error.message };
+  }
+
+  return { albums: data ?? [], error: null };
+}
+
+async function fetchSharedAlbums(client: SupabaseServerClient, userId: string, search: string) {
+  const supabase = client as unknown as SupabaseClient<any>;
+  let query = supabase
+    .from('albums')
+    .select('id, owner_id, name, slug, visibility, created_at, updated_at, album_collaborators!inner(user_id)')
+    .eq('album_collaborators.user_id', userId)
+    .neq('owner_id', userId)
+    .order('updated_at', { ascending: false, nullsFirst: false });
+
+  if (search) {
+    query = query.ilike('name', `%${search}%`);
+  }
+
+  const { data, error } = (await query) as {
+    data: (AlbumRow & { album_collaborators: Array<{ user_id: string }> })[] | null;
+    error: PostgrestError | null;
+  };
+
+  if (error) {
+    return { albums: [] as AlbumRow[], error: error.message };
+  }
+
+  const albums = (data ?? []).map((album) => ({
+    id: album.id,
+    owner_id: album.owner_id,
+    name: album.name,
+    slug: album.slug,
+    visibility: album.visibility,
+    created_at: album.created_at,
+    updated_at: album.updated_at,
+  }));
+
+  return { albums, error: null };
 }

--- a/app/api/packs/[id]/publish/route.ts
+++ b/app/api/packs/[id]/publish/route.ts
@@ -1,73 +1,147 @@
-// app/api/packs/[id]/publish/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServerClient } from '@/lib/supabaseServer';
 
-type AlbumRow = { id: string; owner_id: string };
-type CollaboratorRow = { id: string };
-type PackRow = { id: string; album_id: string; name?: string | null; slug?: string | null };
+import { getServerClient, type SupabaseServerClient } from '@/lib/supabaseServer';
 
-async function canWriteAlbum(userId: string, albumId: string) {
-  const supabase = getSupabaseServerClient();
+type PackRow = {
+  id: string;
+  album_id: string;
+  owner_id: string;
+  public_url: string | null;
+  wa_share_url: string | null;
+};
 
-  const albumRes = await supabase
-    .from('albums')
-    .select('id, owner_id')
+type AlbumRow = {
+  id: string;
+  slug: string;
+  owner_id: string;
+};
+
+async function fetchPack(
+  supabase: SupabaseServerClient,
+  packId: string,
+): Promise<PackRow | null> {
+  const { data, error } = await (supabase.from('packs') as any)
+    .select('id, album_id, owner_id, public_url, wa_share_url')
+    .eq('id', packId)
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return (data as PackRow | null) ?? null;
+}
+
+async function fetchAlbum(
+  supabase: SupabaseServerClient,
+  albumId: string,
+): Promise<AlbumRow | null> {
+  const { data, error } = await (supabase.from('albums') as any)
+    .select('id, slug, owner_id')
     .eq('id', albumId)
     .maybeSingle();
 
-  if (albumRes.error) return false;
-  const album = albumRes.data as AlbumRow | null;
-  if (!album) return false;
-  if (album.owner_id === userId) return true;
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
 
-  const collabRes = await supabase
-    .from('album_collaborators')
+  return (data as AlbumRow | null) ?? null;
+}
+
+async function canWriteAlbum(
+  supabase: SupabaseServerClient,
+  userId: string,
+  albumId: string,
+): Promise<boolean> {
+  const album = await fetchAlbum(supabase, albumId);
+  if (!album) {
+    return false;
+  }
+
+  if (album.owner_id === userId) {
+    return true;
+  }
+
+  const { data, error } = await (supabase.from('album_collaborators') as any)
     .select('id')
     .eq('album_id', albumId)
     .eq('user_id', userId)
     .maybeSingle();
 
-  if (collabRes.error) return false;
-  const collaborator = collabRes.data as CollaboratorRow | null;
-  return !!collaborator;
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return false;
+    }
+    throw error;
+  }
+
+  return Boolean(data);
+}
+
+async function touchAlbum(supabase: SupabaseServerClient, albumId: string) {
+  await (supabase.from('albums') as any)
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', albumId);
 }
 
 export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
-  const supabase = getSupabaseServerClient();
+  const supabase = getServerClient();
 
-  // auth
   const {
     data: { user },
+    error: userError,
   } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  // ambil pack yang mau dipublish
-  const packRes = await supabase
-    .from('packs')
-    .select('id, album_id, name, slug')
-    .eq('id', params.id)
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 401 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const pack = await fetchPack(supabase, params.id);
+  if (!pack) {
+    return NextResponse.json({ error: 'Pack tidak ditemukan' }, { status: 404 });
+  }
+
+  const album = await fetchAlbum(supabase, pack.album_id);
+  if (!album) {
+    return NextResponse.json({ error: 'Album tidak ditemukan' }, { status: 404 });
+  }
+
+  const allowed = await canWriteAlbum(supabase, user.id, album.id);
+  if (!allowed) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+  const publicUrl = `${baseUrl}/p/${album.slug}`;
+  const waUrl = `https://wa.me/?text=${encodeURIComponent(publicUrl)}`;
+
+  const { data: updated, error: updateError } = await (supabase.from('packs') as any)
+    .update({ public_url: publicUrl, wa_share_url: waUrl })
+    .eq('id', pack.id)
+    .select('public_url, wa_share_url')
     .maybeSingle();
 
-  if (packRes.error) return NextResponse.json({ error: packRes.error.message }, { status: 400 });
-  const pack = packRes.data as PackRow | null;
-  if (!pack) return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
+  if (updateError || !updated) {
+    return NextResponse.json(
+      { error: updateError?.message ?? 'Gagal memperbarui pack' },
+      { status: 500 },
+    );
+  }
 
-  // cek izin: owner atau collaborator album
-  const allowed = await canWriteAlbum(user.id, pack.album_id);
-  if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  await touchAlbum(supabase, album.id);
 
-  // siapkan URL publik & link WhatsApp
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
-  const slug = pack.slug ?? pack.id;
-  const publicUrl = `${baseUrl}/packs/${slug}`;
-  const message = `Cek sticker pack "${pack.name ?? 'Sticker Pack'}": ${publicUrl}`;
-  const waUrl = `https://wa.me/?text=${encodeURIComponent(message)}`;
-
-  // tandai pack sebagai publik (sesuaikan kolom tabelmu)
-  await supabase
-    .from('packs')
-    .update({ is_public: true, public_url: publicUrl })
-    .eq('id', pack.id);
-
-  return NextResponse.json({ publicUrl, waUrl });
+  return NextResponse.json({
+    publicUrl: (updated as { public_url: string }).public_url,
+    waUrl: (updated as { wa_share_url: string }).wa_share_url,
+  });
 }

--- a/components/AlbumCard.tsx
+++ b/components/AlbumCard.tsx
@@ -1,69 +1,185 @@
-import Link from 'next/link';
+'use client';
+
 import Image from 'next/image';
-import { MoreVertical, Shield, Users } from 'lucide-react';
-import { Badge } from './ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
-import { Button } from './ui/button';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { CalendarClock, EllipsisVertical, Globe2, Link2, Lock, Users } from 'lucide-react';
 
-export interface AlbumCardProps {
+import { cn, formatCount } from '@/lib/utils';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export type AlbumVisibility = 'public' | 'unlisted' | 'private';
+
+export type AlbumCardProps = {
   id: string;
-  slug: string;
   name: string;
-  cover_url?: string | null;
-  visibility: 'public' | 'unlisted' | 'private';
-  hideActions?: boolean;
-}
-
-const visibilityMap: Record<AlbumCardProps['visibility'], { label: string; icon: React.ReactNode }> = {
-  public: { label: 'Publik', icon: <Users className="h-4 w-4" /> },
-  unlisted: { label: 'Tersembunyi', icon: <Shield className="h-4 w-4" /> },
-  private: { label: 'Pribadi', icon: <Shield className="h-4 w-4" /> }
+  slug: string;
+  visibility: AlbumVisibility;
+  updatedAt: string;
+  stickersCount?: number;
+  thumbnails?: string[];
+  onRename?: (albumId: string) => void;
+  onShare?: (albumId: string) => void;
+  onDelete?: (albumId: string) => void;
+  href?: string;
 };
 
-export function AlbumCard({ id, slug, name, cover_url, visibility, hideActions = false }: AlbumCardProps) {
-  const visibilityProps = visibilityMap[visibility];
-  const publicLink = `/albums/${slug}`;
-  const manageLink = `/albums/${id}`;
+const visibilityConfig: Record<AlbumVisibility, { label: string; icon: JSX.Element; badgeClass: string }> = {
+  public: {
+    label: 'Public',
+    icon: <Globe2 className="h-3.5 w-3.5" aria-hidden />,
+    badgeClass: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  },
+  unlisted: {
+    label: 'Unlisted',
+    icon: <Link2 className="h-3.5 w-3.5" aria-hidden />,
+    badgeClass: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  },
+  private: {
+    label: 'Private',
+    icon: <Lock className="h-3.5 w-3.5" aria-hidden />,
+    badgeClass: 'bg-slate-500/10 text-slate-600 dark:text-slate-400',
+  },
+};
+
+const fallbackColors = ['bg-rose-200/60', 'bg-sky-200/60', 'bg-emerald-200/60', 'bg-violet-200/60'];
+
+export function AlbumCard({
+  id,
+  name,
+  slug,
+  visibility,
+  updatedAt,
+  stickersCount,
+  thumbnails,
+  href,
+  onRename,
+  onShare,
+  onDelete,
+}: AlbumCardProps) {
+  const previewSources = useMemo(() => (thumbnails ?? []).filter(Boolean).slice(0, 6), [thumbnails]);
+  const visibilityProps = visibilityConfig[visibility];
+  const albumHref = href ?? `/albums/${slug}`;
+  const readableUpdatedAt = useMemo(() => {
+    if (!updatedAt) {
+      return '—';
+    }
+
+    const date = new Date(updatedAt);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  }, [updatedAt]);
+
+  const handleRename = () => onRename?.(id);
+  const handleShare = () => onShare?.(id);
+  const handleDelete = () => onDelete?.(id);
+
   return (
-    <Card className="overflow-hidden transition hover:-translate-y-1 hover:shadow-lg">
-      <Link href={hideActions ? publicLink : manageLink} className="block">
-        <div className="relative h-48 w-full overflow-hidden bg-muted">
-          {cover_url ? (
-            <Image src={cover_url} alt={name} fill className="object-cover" />
-          ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">No cover</div>
-          )}
+    <Card className="group flex h-full flex-col overflow-hidden rounded-3xl border border-border/80 bg-card/80 shadow-sm transition-all hover:-translate-y-1 hover:border-border hover:shadow-md">
+      <Link href={albumHref} className="relative block aspect-[3/2] bg-muted">
+        <div className="absolute inset-0 grid grid-cols-3 grid-rows-2 gap-px overflow-hidden bg-border/40 p-2">
+          {Array.from({ length: 6 }).map((_, index) => {
+            const src = previewSources[index];
+            return (
+              <div
+                key={index}
+                className={cn(
+                  'relative overflow-hidden rounded-xl bg-muted/80',
+                  !src && fallbackColors[index % fallbackColors.length],
+                )}
+              >
+                {src ? (
+                  <Image src={src} alt={`${name} preview ${index + 1}`} fill sizes="33vw" className="object-cover" />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-[10px] font-medium uppercase tracking-widest text-muted-foreground/70">
+                    {name.slice(0, 2).toUpperCase() || 'SA'}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </Link>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div>
-          <CardTitle className="text-lg">{name}</CardTitle>
-          <Badge className="mt-2 flex items-center gap-1">
-            {visibilityProps.icon}
-            {visibilityProps.label}
-          </Badge>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 p-4">
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Link href={albumHref} className="truncate text-base font-semibold leading-tight transition hover:text-primary">
+              {name}
+            </Link>
+            <Badge className={cn('flex items-center gap-1 border-none px-2 py-0.5 text-xs', visibilityProps.badgeClass)}>
+              {visibilityProps.icon}
+              {visibilityProps.label}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" aria-hidden />
+              <span>{formatCount(stickersCount ?? 0)} stickers</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <CalendarClock className="h-3.5 w-3.5" aria-hidden />
+              <span>Updated {readableUpdatedAt}</span>
+            </div>
+          </div>
         </div>
-        {!hideActions && (
+        {(onRename || onShare || onDelete) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <MoreVertical className="h-4 w-4" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 rounded-full border border-transparent text-muted-foreground transition hover:border-border/80 hover:text-foreground"
+                aria-label={`Album actions for ${name}`}
+              >
+                <EllipsisVertical className="h-4 w-4" aria-hidden />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href={manageLink}>Kelola</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href={publicLink}>Lihat Publik</Link>
-              </DropdownMenuItem>
+            <DropdownMenuContent align="end" className="w-40 rounded-2xl border border-border bg-card/95 shadow-lg backdrop-blur">
+              {onRename && (
+                <DropdownMenuItem className="cursor-pointer" onSelect={(event) => { event.preventDefault(); handleRename(); }}>
+                  Rename
+                </DropdownMenuItem>
+              )}
+              {onShare && (
+                <DropdownMenuItem className="cursor-pointer" onSelect={(event) => { event.preventDefault(); handleShare(); }}>
+                  Share
+                </DropdownMenuItem>
+              )}
+              {(onRename || onShare) && onDelete && <DropdownMenuSeparator />}
+              {onDelete && (
+                <DropdownMenuItem
+                  className="cursor-pointer text-destructive focus:text-destructive"
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    handleDelete();
+                  }}
+                >
+                  Delete
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}
       </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">{hideActions ? `Slug: ${slug}` : `ID: ${id}`}</p>
+      <CardContent className="p-4 pt-0">
+        <p className="truncate text-xs text-muted-foreground">/{slug}</p>
       </CardContent>
     </Card>
   );

--- a/components/AlbumGrid.tsx
+++ b/components/AlbumGrid.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { AlbumCard, type AlbumVisibility } from '@/components/AlbumCard';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/utils';
+
+import { CreateAlbumDialog } from '@/components/CreateAlbumDialog';
+
+export type AlbumScope = 'all' | 'owned' | 'shared';
+
+type AlbumListItem = {
+  id: string;
+  name: string;
+  slug: string;
+  visibility: AlbumVisibility;
+  updatedAt: string;
+  stickersCount: number;
+  thumbnails: string[];
+};
+
+type AlbumGridProps = {
+  search?: string;
+  defaultScope?: AlbumScope;
+};
+
+const responseSchema = z.object({
+  data: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        slug: z.string(),
+        visibility: z.union([z.literal('public'), z.literal('unlisted'), z.literal('private')]),
+        updatedAt: z.string(),
+        stickersCount: z.number().int().nonnegative(),
+        thumbnails: z.array(z.string()).optional(),
+      }),
+    )
+    .default([]),
+});
+
+const updatePayloadSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  visibility: z.union([z.literal('public'), z.literal('unlisted'), z.literal('private')]).optional(),
+});
+
+const visibilityOptions: { value: AlbumVisibility; label: string }[] = [
+  { value: 'public', label: 'Public' },
+  { value: 'unlisted', label: 'Unlisted' },
+  { value: 'private', label: 'Private' },
+];
+
+export function AlbumGrid({ search, defaultScope = 'all' }: AlbumGridProps) {
+  const [scope, setScope] = useState<AlbumScope>(defaultScope);
+  const [renameTarget, setRenameTarget] = useState<AlbumListItem | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AlbumListItem | null>(null);
+  const [renameVisibility, setRenameVisibility] = useState<AlbumVisibility>('private');
+  const [renameName, setRenameName] = useState('');
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const normalizedSearch = useMemo(() => search?.trim() ?? '', [search]);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['albums', scope, normalizedSearch],
+    queryFn: async (): Promise<AlbumListItem[]> => {
+      const params = new URLSearchParams();
+      if (scope !== 'all') {
+        params.set('scope', scope);
+      }
+      if (normalizedSearch) {
+        params.set('q', normalizedSearch);
+      }
+
+      const response = await fetch(`/api/albums${params.size > 0 ? `?${params.toString()}` : ''}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to load albums');
+      }
+
+      const json = await response.json();
+      const parsed = responseSchema.safeParse(json);
+      if (!parsed.success) {
+        throw new Error('Invalid response from server');
+      }
+
+      return parsed.data.data.map((album) => ({
+        id: album.id,
+        name: album.name,
+        slug: album.slug,
+        visibility: album.visibility,
+        updatedAt: album.updatedAt,
+        stickersCount: album.stickersCount,
+        thumbnails: album.thumbnails ?? [],
+      }));
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ albumId, payload }: { albumId: string; payload: z.infer<typeof updatePayloadSchema> }) => {
+      const body = updatePayloadSchema.parse(payload);
+      const response = await fetch(`/api/albums/${albumId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error ?? 'Failed to update album');
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['albums'] });
+      showToast({
+        title: 'Album updated',
+        variant: 'success',
+      });
+    },
+    onError: (error: Error) => {
+      showToast({
+        title: 'Unable to update album',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+    onSettled: () => {
+      setRenameTarget(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (albumId: string) => {
+      const response = await fetch(`/api/albums/${albumId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error ?? 'Failed to delete album');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['albums'] });
+      showToast({
+        title: 'Album deleted',
+        variant: 'success',
+      });
+    },
+    onError: (error: Error) => {
+      showToast({
+        title: 'Unable to delete album',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+    onSettled: () => {
+      setDeleteTarget(null);
+    },
+  });
+
+  const handleScopeChange = (value: string) => {
+    if (value === scope) return;
+    if (value === 'all' || value === 'owned' || value === 'shared') {
+      setScope(value);
+    }
+  };
+
+  const handleRenameRequest = (albumId: string) => {
+    const album = data?.find((item) => item.id === albumId);
+    if (!album) return;
+    setRenameTarget(album);
+    setRenameName(album.name);
+    setRenameVisibility(album.visibility);
+  };
+
+  const handleDeleteRequest = (albumId: string) => {
+    const album = data?.find((item) => item.id === albumId);
+    if (!album) return;
+    setDeleteTarget(album);
+  };
+
+  const handleRenameSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!renameTarget) return;
+
+    const parsed = updatePayloadSchema.safeParse({
+      name: renameName.trim(),
+      visibility: renameVisibility,
+    });
+
+    if (!parsed.success) {
+      showToast({
+        title: 'Please check the album name',
+        description: parsed.error.issues[0]?.message ?? 'Invalid input',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    updateMutation.mutate({ albumId: renameTarget.id, payload: parsed.data });
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget.id);
+  };
+
+  const albums = data ?? [];
+  const showEmpty = !isLoading && !isError && albums.length === 0;
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <Tabs value={scope} onValueChange={handleScopeChange} className="w-full sm:w-auto">
+          <TabsList className="grid w-full grid-cols-3 rounded-2xl bg-muted/60 p-1">
+            <TabsTrigger value="all" className="rounded-2xl text-sm font-medium">All</TabsTrigger>
+            <TabsTrigger value="owned" className="rounded-2xl text-sm font-medium">Owned</TabsTrigger>
+            <TabsTrigger value="shared" className="rounded-2xl text-sm font-medium">Shared</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <CreateAlbumDialog>
+          <Button className="rounded-2xl px-5">Create Album</Button>
+        </CreateAlbumDialog>
+      </div>
+      {isLoading && <AlbumGridSkeleton />}
+      {isError && (
+        <div className="rounded-3xl border border-destructive/50 bg-destructive/10 p-6 text-sm text-destructive">
+          Unable to load albums. Please try again.
+        </div>
+      )}
+      {showEmpty && (
+        <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-border bg-card/50 px-8 py-16 text-center">
+          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted text-3xl">🗂️</div>
+          <h3 className="text-lg font-semibold">No albums yet</h3>
+          <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+            Create your first sticker album to start organizing and sharing your WhatsApp stickers.
+          </p>
+          <CreateAlbumDialog>
+            <Button className="mt-6 rounded-2xl px-6">Create your first album</Button>
+          </CreateAlbumDialog>
+        </div>
+      )}
+      {!isLoading && !isError && albums.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {albums.map((album) => (
+            <AlbumCard
+              key={album.id}
+              id={album.id}
+              name={album.name}
+              slug={album.slug}
+              visibility={album.visibility}
+              updatedAt={album.updatedAt}
+              stickersCount={album.stickersCount}
+              thumbnails={album.thumbnails}
+              onRename={handleRenameRequest}
+              onDelete={handleDeleteRequest}
+            />
+          ))}
+        </div>
+      )}
+
+      <Dialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameTarget(null);
+            setRenameName('');
+            setRenameVisibility('private');
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename album</DialogTitle>
+            <DialogDescription>Update the album name and visibility.</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleRenameSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="album-name" className="text-sm font-medium text-foreground">
+                Album name
+              </label>
+              <Input
+                id="album-name"
+                value={renameName}
+                onChange={(event) => setRenameName(event.target.value)}
+                required
+                placeholder="My sticker album"
+                className="rounded-2xl"
+                disabled={updateMutation.isPending}
+              />
+            </div>
+            <div className="space-y-2">
+              <span className="text-sm font-medium text-foreground">Visibility</span>
+              <div className="grid grid-cols-3 gap-2">
+                {visibilityOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setRenameVisibility(option.value)}
+                    className={cn(
+                      'flex items-center justify-center rounded-2xl border border-border/60 px-3 py-2 text-sm transition',
+                      renameVisibility === option.value && 'border-primary/60 bg-primary/10 text-primary',
+                    )}
+                    disabled={updateMutation.isPending}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                className="rounded-2xl"
+                onClick={() => setRenameTarget(null)}
+                disabled={updateMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" className="rounded-2xl" disabled={updateMutation.isPending}>
+                {updateMutation.isPending ? 'Saving...' : 'Save changes'}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete album</DialogTitle>
+            <DialogDescription>
+              This will permanently remove the album and its stickers. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <span>
+              Album: <span className="font-medium text-foreground">{deleteTarget?.name}</span>
+            </span>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              className="rounded-2xl"
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleteMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              className="rounded-2xl"
+              onClick={handleDeleteConfirm}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete album'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}
+
+function AlbumGridSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Skeleton key={index} className="h-64 w-full rounded-3xl" />
+      ))}
+    </div>
+  );
+}

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+
+type ConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void | Promise<void>;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  isConfirmDestructive?: boolean;
+};
+
+export function ConfirmDialog(props: ConfirmDialogProps) {
+  const {
+    open,
+    onOpenChange,
+    onConfirm,
+    title,
+    description,
+    confirmText = 'Confirm',
+    cancelText = 'Cancel',
+    isConfirmDestructive = false
+  } = props;
+  const [isPending, setIsPending] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    if (isPending) return;
+    try {
+      setIsPending(true);
+      await onConfirm();
+      onOpenChange(false);
+    } finally {
+      setIsPending(false);
+    }
+  }, [isPending, onConfirm, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-4">
+        <DialogHeader className="space-y-2 text-left">
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              {cancelText}
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            variant={isConfirmDestructive ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+            disabled={isPending}
+          >
+            {isPending ? 'Processing…' : confirmText}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ConfirmDialog;

--- a/components/CreateAlbumDialog.tsx
+++ b/components/CreateAlbumDialog.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { type ReactNode, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/utils';
+
+const formSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(120, 'Name is too long'),
+  visibility: z.union([z.literal('public'), z.literal('unlisted'), z.literal('private')]).default('private'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type CreateAlbumDialogProps = {
+  children?: ReactNode;
+};
+
+const visibilityOptions: { value: FormValues['visibility']; label: string; description: string }[] = [
+  {
+    value: 'public',
+    label: 'Public',
+    description: 'Visible to anyone with the link and discoverable.',
+  },
+  {
+    value: 'unlisted',
+    label: 'Unlisted',
+    description: 'Accessible with the link but not listed publicly.',
+  },
+  {
+    value: 'private',
+    label: 'Private',
+    description: 'Only collaborators you invite can view.',
+  },
+];
+
+export function CreateAlbumDialog({ children }: CreateAlbumDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [values, setValues] = useState<FormValues>({ name: '', visibility: 'private' });
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: async (payload: FormValues) => {
+      const response = await fetch('/api/albums', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error ?? 'Failed to create album');
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['albums'] });
+      showToast({
+        title: 'Album created',
+        variant: 'success',
+      });
+      setValues({ name: '', visibility: 'private' });
+      setOpen(false);
+    },
+    onError: (error: Error) => {
+      showToast({
+        title: 'Unable to create album',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = formSchema.safeParse({
+      name: values.name,
+      visibility: values.visibility,
+    });
+
+    if (!parsed.success) {
+      const firstError = parsed.error.issues[0]?.message ?? 'Invalid input';
+      showToast({
+        title: 'Check the form',
+        description: firstError,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    mutation.mutate(parsed.data);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          setValues({ name: '', visibility: 'private' });
+        }
+      }}
+    >
+      <DialogTrigger asChild>{children ?? <Button className="rounded-2xl">Create album</Button>}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a new album</DialogTitle>
+          <DialogDescription>Organize your stickers into a new collection.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <label htmlFor="create-album-name" className="text-sm font-medium text-foreground">
+              Album name
+            </label>
+            <Input
+              id="create-album-name"
+              value={values.name}
+              onChange={(event) => setValues((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="My sticker album"
+              autoFocus
+              required
+              className="rounded-2xl"
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-3">
+            <span className="text-sm font-medium text-foreground">Visibility</span>
+            <div className="grid gap-2">
+              {visibilityOptions.map((option) => {
+                const isActive = values.visibility === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={cn(
+                      'flex flex-col rounded-2xl border border-border/70 p-3 text-left transition hover:border-border',
+                      isActive && 'border-primary/60 bg-primary/10 text-primary',
+                    )}
+                    onClick={() => setValues((prev) => ({ ...prev, visibility: option.value }))}
+                    disabled={mutation.isPending}
+                  >
+                    <span className="text-sm font-semibold">{option.label}</span>
+                    <span className="text-xs text-muted-foreground">{option.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              className="rounded-2xl"
+              onClick={() => setOpen(false)}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" className="rounded-2xl" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Creating…' : 'Create album'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,74 +1,71 @@
 'use client';
 
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { Search, User } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
+import { type ChangeEvent, useMemo } from 'react';
+import { Search } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
 import { ThemeToggle } from './ThemeToggle';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
-import { createClient } from '@/lib/supabaseClient';
+import { Input } from './ui/input';
 
-export function NavBar() {
-  const [query, setQuery] = useState('');
-  const router = useRouter();
+export type NavBarProps = {
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  userLabel?: string | null;
+};
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      const params = new URLSearchParams(window.location.search);
-      if (query) {
-        params.set('q', query);
-      } else {
-        params.delete('q');
-      }
-      router.push(`?${params.toString()}`);
-    }, 400);
-    return () => clearTimeout(timeout);
-  }, [query, router]);
+export function NavBar({ searchValue, onSearchChange, userLabel }: NavBarProps) {
+  const initials = useMemo(() => {
+    const source = userLabel?.trim();
+    if (!source) {
+      return '?';
+    }
 
-  const supabase = createClient();
+    const [firstWord] = source.split(/\s+/);
+    return firstWord?.charAt(0)?.toUpperCase() || '?';
+  }, [userLabel]);
 
-  const signOut = async () => {
-    await supabase.auth.signOut();
-    router.refresh();
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onSearchChange(event.target.value);
   };
 
   return (
-    <header className="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4">
-        <Link href="/" className="flex items-center gap-2 text-lg font-semibold">
-          <span className="rounded-full bg-primary px-2 py-1 text-xs uppercase tracking-wide text-primary-foreground">
-            WA
-          </span>
-          Sticker Album
-        </Link>
-        <div className="hidden flex-1 items-center gap-3 md:flex">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Cari album..."
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              className="pl-10"
-            />
+    <header className="w-full px-4 py-4">
+      <div
+        className={cn(
+          'mx-auto flex w-full max-w-6xl flex-col gap-4 rounded-3xl border border-border bg-card/80 p-4 shadow-sm backdrop-blur-sm transition-colors',
+          'md:flex-row md:items-center md:justify-between md:gap-6',
+        )}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold uppercase tracking-widest text-primary">Sticker Album</span>
+            <span className="text-xs text-muted-foreground">Organize and share your WhatsApp stickers</span>
+          </div>
+          <div className="flex items-center gap-2 md:hidden">
+            <ThemeToggle />
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+              {initials}
+            </div>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <ThemeToggle />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <User className="h-5 w-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href="/dashboard">Dashboard</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={signOut}>Keluar</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+        <div className="flex flex-1 items-center gap-4">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={searchValue}
+              onChange={handleChange}
+              placeholder="Search albums"
+              className="h-11 rounded-2xl border-border pl-10"
+              aria-label="Search albums"
+            />
+          </div>
+          <div className="hidden items-center gap-2 md:flex">
+            <ThemeToggle />
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+              {initials}
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/components/PackBuilder.tsx
+++ b/components/PackBuilder.tsx
@@ -1,21 +1,24 @@
 'use client';
 
-import React, { useCallback, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/useToast';
 
 type Sticker = {
   id: string;
   album_id: string;
   file_url: string;
-  thumb_url?: string | null;
-  title?: string | null;
-  size_kb?: number | null;
-  order_index?: number | null;
-  created_at?: string;
+  thumb_url: string | null;
+  title: string | null;
+  size_kb: number | null;
+  sort_index: number;
+  created_at: string | null;
 };
 
 type StickersResponse = { data: Sticker[] };
@@ -23,13 +26,13 @@ type StickersResponse = { data: Sticker[] };
 type CreatePackPayload = {
   albumId: string;
   name: string;
-  author: string;
+  author?: string;
   stickerIds: string[];
 };
 
 type CreatePackResponse = {
   id: string;
-  exported_zip_url?: string;
+  exported_zip_url: string | null;
 };
 
 type PublishResponse = {
@@ -42,7 +45,7 @@ interface PackBuilderProps {
 }
 
 export function PackBuilder({ albumId }: PackBuilderProps) {
-  const qc = useQueryClient();
+  const queryClient = useQueryClient();
   const { showToast } = useToast();
 
   const [name, setName] = useState('Sticker Pack');
@@ -51,214 +54,315 @@ export function PackBuilder({ albumId }: PackBuilderProps) {
   const [lastPack, setLastPack] = useState<CreatePackResponse | null>(null);
   const [shareInfo, setShareInfo] = useState<PublishResponse | null>(null);
 
-  /** ───────────────────────────
-   *  Load stickers
-   *  ─────────────────────────── */
-  const { data, isLoading, isError, error } = useQuery<StickersResponse>({
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+  } = useQuery<StickersResponse>({
     queryKey: ['album', albumId, 'stickers'],
     queryFn: async () => {
-      const res = await fetch(`/api/albums/${albumId}/stickers`);
-      if (!res.ok) throw new Error('Gagal memuat sticker');
-      return (await res.json()) as StickersResponse;
+      const response = await fetch(`/api/albums/${albumId}/stickers`);
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error((payload as { error?: string }).error ?? 'Gagal memuat sticker');
+      }
+
+      return (await response.json()) as StickersResponse;
     },
   });
 
-  // ✅ normalisasi ke variabel stabil (menghindari logical expression di deps)
-  const stickersData = data?.data as Sticker[] | undefined;
-  const stickers = useMemo<Sticker[]>(() => stickersData ?? [], [stickersData]);
+  const stickers = useMemo<Sticker[]>(() => ((data?.data ?? []) as Sticker[]), [data]);
 
-  /** ───────────────────────────
-   *  Helpers seleksi
-   *  ─────────────────────────── */
-  const toggle = useCallback((id: string) => {
+  useEffect(() => {
+    setSelected((prev) => prev.filter((id) => stickers.some((sticker) => sticker.id === id)));
+  }, [stickers]);
+
+  const toggleSelection = useCallback((id: string) => {
     setSelected((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id],
     );
   }, []);
 
-  const move = useCallback((id: string, direction: number) => {
+  const moveSelection = useCallback((id: string, direction: number) => {
     setSelected((prev) => {
-      const i = prev.indexOf(id);
-      if (i < 0) return prev;
-      const nextI = Math.max(0, Math.min(prev.length - 1, i + direction));
-      if (i === nextI) return prev;
-      const next = [...prev];
-      const [rm] = next.splice(i, 1);
-      next.splice(nextI, 0, rm);
-      return next;
+      const index = prev.indexOf(id);
+      if (index === -1) {
+        return prev;
+      }
+
+      const nextIndex = Math.max(0, Math.min(prev.length - 1, index + direction));
+      if (index === nextIndex) {
+        return prev;
+      }
+
+      const draft = [...prev];
+      const [item] = draft.splice(index, 1);
+      draft.splice(nextIndex, 0, item);
+      return draft;
     });
   }, []);
 
   const selectAll = useCallback(() => {
-    setSelected(stickers.map((s) => s.id));
+    setSelected(stickers.map((sticker) => sticker.id));
   }, [stickers]);
 
-  const clearSelection = useCallback(() => setSelected([]), []);
+  const clearSelection = useCallback(() => {
+    setSelected([]);
+  }, []);
 
-  // ✅ derived data stabil
-  const selectedStickers = useMemo(
-    () => selected.map((id) => stickers.find((s) => s.id === id)).filter(Boolean) as Sticker[],
-    [selected, stickers]
-  );
-  const canBuild = useMemo(() => selected.length > 0, [selected]);
+  const selectedStickers = useMemo(() => {
+    const map = new Map(stickers.map((sticker) => [sticker.id, sticker]));
+    return selected
+      .map((id) => map.get(id))
+      .filter((value): value is Sticker => Boolean(value));
+  }, [selected, stickers]);
 
-  /** ───────────────────────────
-   *  Mutations
-   *  ─────────────────────────── */
+  const canBuild = selected.length > 0 && !isLoading && !isFetching;
+
   const packMutation = useMutation<CreatePackResponse, Error, void>({
     mutationFn: async () => {
-      const payload: CreatePackPayload = { albumId, name, author, stickerIds: selected };
-      const res = await fetch('/api/packs', {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Nama pack wajib diisi');
+      }
+      if (selected.length === 0) {
+        throw new Error('Pilih minimal satu sticker');
+      }
+
+      const payload: CreatePackPayload = {
+        albumId,
+        name: trimmedName,
+        stickerIds: [...selected],
+      };
+
+      const trimmedAuthor = author.trim();
+      if (trimmedAuthor) {
+        payload.author = trimmedAuthor;
+      }
+
+      const response = await fetch('/api/packs', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(payload),
       });
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}));
-        throw new Error(j?.error ?? 'Gagal membuat pack');
+
+      if (!response.ok) {
+        const message = await response.json().catch(() => ({}));
+        throw new Error((message as { error?: string }).error ?? 'Gagal membuat pack');
       }
-      return (await res.json()) as CreatePackResponse;
+
+      return (await response.json()) as CreatePackResponse;
     },
     onSuccess: (payload) => {
-      showToast({ title: 'Pack dibuat', description: 'ZIP siap diunduh', variant: 'success' });
-      qc.invalidateQueries({ queryKey: ['packs', albumId] });
-      setSelected([]);
       setLastPack(payload);
       setShareInfo(null);
+      setSelected([]);
+      showToast({
+        title: 'Pack dibuat',
+        description: 'ZIP siap diunduh',
+        variant: 'success',
+      });
+      queryClient.invalidateQueries({ queryKey: ['packs', albumId] }).catch(() => undefined);
     },
-    onError: (e) => {
-      showToast({ title: 'Gagal', description: e.message, variant: 'destructive' });
+    onError: (err) => {
+      showToast({
+        title: 'Gagal membuat pack',
+        description: err.message,
+        variant: 'destructive',
+      });
     },
   });
 
   const publishMutation = useMutation<PublishResponse, Error, void>({
     mutationFn: async () => {
-      if (!lastPack?.id) throw new Error('Belum ada pack untuk dipublish');
-      const res = await fetch(`/api/packs/${lastPack.id}/publish`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ makePublic: true }),
-      });
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}));
-        throw new Error(j?.error ?? 'Gagal mempublish pack');
+      if (!lastPack?.id) {
+        throw new Error('Belum ada pack yang siap publish');
       }
-      return (await res.json()) as PublishResponse;
+
+      const response = await fetch(`/api/packs/${lastPack.id}/publish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const message = await response.json().catch(() => ({}));
+        throw new Error((message as { error?: string }).error ?? 'Gagal mempublish pack');
+      }
+
+      return (await response.json()) as PublishResponse;
     },
-    onSuccess: (data) => {
-      setShareInfo(data);
-      showToast({ title: 'Pack siap dibagikan', variant: 'success' });
+    onSuccess: (payload) => {
+      setShareInfo(payload);
+      showToast({
+        title: 'Pack siap dibagikan',
+        description: 'Bagikan link publik ke teman-teman',
+        variant: 'success',
+      });
     },
-    onError: (e) => {
-      showToast({ title: 'Gagal', description: e.message, variant: 'destructive' });
+    onError: (err) => {
+      showToast({
+        title: 'Gagal publish pack',
+        description: err.message,
+        variant: 'destructive',
+      });
     },
   });
 
-  /** ───────────────────────────
-   *  UI
-   *  ─────────────────────────── */
   if (isError) {
     return (
-      <div className="rounded-3xl border border-border bg-muted/30 p-4 text-sm text-destructive">
-        {(error as Error)?.message ?? 'Gagal memuat sticker'}
+      <div className="rounded-3xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        {(error as Error | undefined)?.message ?? 'Terjadi kesalahan saat memuat sticker'}
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-2">
-        {/* Panel kiri */}
-        <div className="space-y-3">
-          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nama pack" />
-          <Input value={author} onChange={(e) => setAuthor(e.target.value)} placeholder="Nama pembuat" />
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="space-y-4 rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="space-y-3">
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Nama pack"
+            />
+            <Input
+              value={author}
+              onChange={(event) => setAuthor(event.target.value)}
+              placeholder="Nama pembuat (opsional)"
+            />
+          </div>
 
-          <div className="flex gap-2">
-            <Button type="button" variant="outline" onClick={selectAll} disabled={isLoading || stickers.length === 0}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={selectAll}
+              disabled={isLoading || isFetching || stickers.length === 0}
+            >
               Pilih semua
             </Button>
             <Button type="button" variant="ghost" onClick={clearSelection} disabled={selected.length === 0}>
-              Bersihkan
+              Bersihkan pilihan
             </Button>
           </div>
 
-          <Button
-            onClick={() => packMutation.mutate()}
-            disabled={!canBuild || packMutation.isPending}
-            className="w-full"
-          >
-            {packMutation.isPending ? 'Memproses…' : 'Buat & Export ZIP'}
-          </Button>
-
-          {lastPack?.exported_zip_url && (
-            <a
-              href={lastPack.exported_zip_url}
-              target="_blank"
-              rel="noreferrer"
-              className="block text-sm text-primary underline"
-            >
-              Unduh ZIP Terbaru
-            </a>
-          )}
-
-          {lastPack?.id && (
+          <div className="space-y-3">
             <Button
               type="button"
-              variant="secondary"
-              onClick={() => publishMutation.mutate()}
-              disabled={publishMutation.isPending}
               className="w-full"
+              onClick={() => packMutation.mutate()}
+              disabled={!canBuild || packMutation.isPending}
             >
-              {publishMutation.isPending ? 'Menyiapkan share…' : 'Publish & Buat Link'}
+              {packMutation.isPending ? 'Menyiapkan ZIP…' : 'Buat & Export ZIP'}
             </Button>
-          )}
 
-          {shareInfo && (
+            {lastPack?.exported_zip_url ? (
+              <a
+                href={lastPack.exported_zip_url}
+                target="_blank"
+                rel="noreferrer"
+                className="block text-center text-sm font-medium text-primary underline"
+              >
+                Unduh ZIP terbaru
+              </a>
+            ) : null}
+
+            {lastPack?.id ? (
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full"
+                onClick={() => publishMutation.mutate()}
+                disabled={publishMutation.isPending}
+              >
+                {publishMutation.isPending ? 'Menyiapkan link…' : 'Publish & Buat Link'}
+              </Button>
+            ) : null}
+          </div>
+
+          {shareInfo ? (
             <div className="rounded-2xl border border-border bg-muted/40 p-4 text-sm">
-              <p className="font-medium">Link Publik:</p>
-              <a href={shareInfo.publicUrl} target="_blank" rel="noreferrer" className="text-primary underline">
+              <p className="font-semibold">Link Publik</p>
+              <a
+                href={shareInfo.publicUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="break-all text-primary underline"
+              >
                 {shareInfo.publicUrl}
               </a>
-              <p className="mt-2 font-medium">WhatsApp:</p>
-              <a href={shareInfo.waUrl} target="_blank" rel="noreferrer" className="text-primary underline">
+              <p className="mt-3 font-semibold">WhatsApp</p>
+              <a
+                href={shareInfo.waUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="break-all text-primary underline"
+              >
                 {shareInfo.waUrl}
               </a>
             </div>
-          )}
+          ) : null}
         </div>
 
-        {/* Panel kanan: list pilihan */}
-        <div className="rounded-3xl border border-border p-4">
-          <p className="mb-3 text-sm font-medium">
-            Sticker dipilih ({selected.length}) {isLoading ? '• Memuat…' : ''}
-          </p>
-          <div className="space-y-3">
-            {selectedStickers.length ? (
+        <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-semibold">Sticker dipilih ({selected.length})</p>
+            {isFetching ? <p className="text-xs text-muted-foreground">Memuat…</p> : null}
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {selectedStickers.length > 0 ? (
               selectedStickers.map((sticker) => (
-                <div key={sticker.id} className="flex items-center gap-3">
+                <div key={sticker.id} className="flex items-center gap-3 rounded-2xl border border-border/60 p-2">
                   <div className="relative h-16 w-16 overflow-hidden rounded-2xl bg-muted">
                     <Image
                       src={sticker.thumb_url ?? sticker.file_url}
                       alt={sticker.title ?? 'Sticker'}
                       fill
+                      sizes="64px"
                       className="object-cover"
                     />
                   </div>
                   <div className="flex-1">
                     <p className="text-sm font-medium">{sticker.title ?? 'Tanpa nama'}</p>
-                    {typeof sticker.size_kb === 'number' && (
-                      <p className="text-xs text-muted-foreground">{sticker.size_kb}KB</p>
-                    )}
+                    {typeof sticker.size_kb === 'number' ? (
+                      <p className="text-xs text-muted-foreground">{sticker.size_kb} KB</p>
+                    ) : null}
                   </div>
                   <div className="flex items-center gap-1">
-                    <Button variant="ghost" size="sm" onClick={() => move(sticker.id, -1)} aria-label="Ke atas">
-                      ↑
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => moveSelection(sticker.id, -1)}
+                      aria-label="Geser ke atas"
+                    >
+                      <ChevronUp className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm" onClick={() => move(sticker.id, 1)} aria-label="Ke bawah">
-                      ↓
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => moveSelection(sticker.id, 1)}
+                      aria-label="Geser ke bawah"
+                    >
+                      <ChevronDown className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm" onClick={() => toggle(sticker.id)} aria-label="Hapus dari pilihan">
-                      ×
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => toggleSelection(sticker.id)}
+                      aria-label="Hapus dari pilihan"
+                    >
+                      <X className="h-4 w-4" />
                     </Button>
                   </div>
                 </div>
@@ -270,42 +374,56 @@ export function PackBuilder({ albumId }: PackBuilderProps) {
         </div>
       </div>
 
-      {/* Semua sticker */}
-      <div>
-        <p className="mb-3 text-sm font-medium">Semua Sticker</p>
+      <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <p className="text-sm font-semibold">Semua Sticker</p>
+          {isFetching ? <p className="text-xs text-muted-foreground">Memuat…</p> : null}
+        </div>
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-6">
-          {isLoading && stickers.length === 0 ? (
-            Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="h-36 rounded-3xl border border-border bg-muted/30" />
-            ))
-          ) : (
-            stickers.map((sticker) => {
-              const active = selected.includes(sticker.id);
-              return (
-                <button
-                  key={sticker.id}
-                  onClick={() => toggle(sticker.id)}
-                  className={`relative overflow-hidden rounded-3xl border border-border p-2 transition ${
-                    active ? 'ring-2 ring-primary' : 'hover:border-primary'
-                  }`}
-                  aria-pressed={active}
-                  aria-label={active ? 'Batalkan pilih' : 'Pilih'}
-                >
-                  <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-muted">
-                    <Image
-                      src={sticker.thumb_url ?? sticker.file_url}
-                      alt={sticker.title ?? 'Sticker'}
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                  <p className="mt-2 line-clamp-1 text-xs font-medium">
-                    {sticker.title ?? 'Tanpa nama'}
-                  </p>
-                </button>
-              );
-            })
-          )}
+          {isLoading && stickers.length === 0
+            ? Array.from({ length: 8 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-36 rounded-3xl border border-border bg-muted/40 animate-pulse"
+                />
+              ))
+            : null}
+
+          {!isLoading && stickers.length === 0 ? (
+            <div className="col-span-full flex flex-col items-center justify-center rounded-3xl border border-dashed border-border/60 bg-muted/30 p-10 text-center">
+              <p className="text-sm font-medium">Belum ada sticker di album ini.</p>
+              <p className="mt-1 text-xs text-muted-foreground">Unggah sticker terlebih dahulu untuk membangun pack.</p>
+            </div>
+          ) : null}
+
+          {stickers.map((sticker) => {
+            const active = selected.includes(sticker.id);
+            return (
+              <button
+                key={sticker.id}
+                type="button"
+                onClick={() => toggleSelection(sticker.id)}
+                className={cn(
+                  'group relative overflow-hidden rounded-3xl border border-border p-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                  active ? 'border-primary ring-2 ring-primary' : 'hover:border-primary',
+                )}
+                aria-pressed={active}
+              >
+                <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-muted">
+                  <Image
+                    src={sticker.thumb_url ?? sticker.file_url}
+                    alt={sticker.title ?? 'Sticker'}
+                    fill
+                    sizes="120px"
+                    className="object-cover transition group-hover:scale-[1.03]"
+                  />
+                </div>
+                <p className="mt-2 line-clamp-1 text-xs font-medium">
+                  {sticker.title ?? 'Tanpa nama'}
+                </p>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,14 +1,31 @@
 'use client';
 
 import * as React from 'react';
-import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { ToastProvider } from '@/hooks/useToast';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
 import { Toaster } from '@/components/Toaster';
+import { ToastProvider } from '@/hooks/useToast';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 10 * 60 * 1000,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: true,
+        retry: 1,
+      },
+      mutations: {
+        retry: 1,
+      },
+    },
+  });
+}
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = React.useState(() => new QueryClient());
+  const [queryClient] = React.useState(() => createQueryClient());
 
   return (
     <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
@@ -17,7 +34,6 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           {children}
           <Toaster />
         </ToastProvider>
-        <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </NextThemesProvider>
   );

--- a/components/QRCodeCard.tsx
+++ b/components/QRCodeCard.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export type QRCodeCardProps = {
+  url: string;
+};
+
+export function QRCodeCard({ url }: QRCodeCardProps) {
+  const encodedUrl = encodeURIComponent(url);
+
+  return (
+    <Card className="flex h-full flex-col items-center gap-6 rounded-3xl border border-border/80 bg-card/80 p-6 text-center shadow-sm">
+      <CardHeader className="space-y-2 text-center">
+        <CardTitle className="text-lg font-semibold">Scan to open</CardTitle>
+        <CardDescription className="break-all text-xs text-muted-foreground">{url}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex w-full flex-1 flex-col items-center gap-4 pt-0">
+        <div className="rounded-3xl border border-border/70 bg-white p-3 shadow-inner">
+          <img
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encodedUrl}`}
+            alt="QR code for public album"
+            className="h-44 w-44 object-contain"
+            width={180}
+            height={180}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">Point your camera to visit instantly.</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/StickerCard.tsx
+++ b/components/StickerCard.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Image from 'next/image';
+import { ArrowDown, ArrowUp, Check, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface StickerCardProps {
+  id: string;
+  thumbUrl: string | null;
+  title?: string | null;
+  selected: boolean;
+  onSelectToggle: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDelete: () => void;
+}
+
+export function StickerCard({
+  thumbUrl,
+  title,
+  selected,
+  onSelectToggle,
+  onMoveDown,
+  onMoveUp,
+  onDelete,
+}: StickerCardProps) {
+  return (
+    <div
+      className={cn(
+        'group relative flex flex-col rounded-3xl border border-border bg-card p-3 shadow-sm transition hover:border-primary/60',
+        selected && 'ring-2 ring-primary',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelectToggle}
+        aria-pressed={selected}
+        className={cn(
+          'absolute left-3 top-3 flex h-8 w-8 items-center justify-center rounded-full border border-border bg-background/90 text-muted-foreground transition hover:border-primary hover:bg-primary hover:text-primary-foreground',
+          selected && 'border-primary bg-primary text-primary-foreground',
+        )}
+      >
+        {selected && <Check className="h-4 w-4" />}
+        {!selected && <span className="text-xs font-medium">Pilih</span>}
+      </button>
+
+      <div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-muted">
+        {thumbUrl ? (
+          <Image
+            src={thumbUrl}
+            alt={title ?? 'Sticker'}
+            fill
+            sizes="(min-width: 1024px) 160px, (min-width: 768px) 25vw, 45vw"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+            Tidak ada preview
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2 text-sm">
+        <p className="truncate font-medium text-foreground">{title ?? 'Sticker'}</p>
+        <div className="flex items-center gap-1 opacity-0 transition group-hover:opacity-100">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 rounded-full"
+            onClick={onMoveUp}
+            aria-label="Geser ke atas"
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 rounded-full"
+            onClick={onMoveDown}
+            aria-label="Geser ke bawah"
+          >
+            <ArrowDown className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 rounded-full text-destructive hover:bg-destructive/10"
+            onClick={onDelete}
+            aria-label="Hapus sticker"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StickerCard;

--- a/components/StickerGrid.tsx
+++ b/components/StickerGrid.tsx
@@ -1,111 +1,262 @@
 'use client';
 
-import Image from 'next/image';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
-import { Badge } from './ui/badge';
+import { ImageOff, Loader2, Trash2 } from 'lucide-react';
+
+import { StickerCard } from '@/components/StickerCard';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/useToast';
+import { formatCount } from '@/lib/utils';
 
 interface StickerGridProps {
   albumId: string;
 }
+
+type StickerItem = {
+  id: string;
+  file_url: string;
+  thumb_url: string | null;
+  title: string | null;
+  size_kb: number | null;
+  sort_index: number;
+  created_at: string | null;
+};
+
+type StickerListResponse = {
+  data: StickerItem[];
+};
+
+const STICKER_QUERY_KEY = 'stickers';
 
 export function StickerGrid({ albumId }: StickerGridProps) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
   const [selected, setSelected] = useState<string[]>([]);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['album', albumId, 'stickers'],
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery<StickerListResponse, Error>({
+    queryKey: ['album', albumId, STICKER_QUERY_KEY],
     queryFn: async () => {
       const response = await fetch(`/api/albums/${albumId}/stickers`);
-      if (!response.ok) throw new Error('Gagal memuat sticker');
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = typeof payload?.error === 'string' ? payload.error : 'Gagal memuat sticker';
+        throw new Error(message);
+      }
       return response.json();
-    }
+    },
   });
 
-  const updateSticker = useMutation({
-    mutationFn: async (payload: { id: string; title?: string; tags?: string[] }) => {
+  const stickers = useMemo(() => data?.data ?? [], [data]);
+
+  useEffect(() => {
+    if (stickers.length === 0) {
+      setSelected([]);
+      return;
+    }
+    setSelected((prev) => prev.filter((id) => stickers.some((sticker) => sticker.id === id)));
+  }, [stickers]);
+
+  const reorderMutation = useMutation<
+    { ok: true },
+    Error,
+    { orders: Array<{ id: string; sort_index: number }> }
+  >({
+    mutationFn: async ({ orders }) => {
       const response = await fetch(`/api/albums/${albumId}/stickers`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
+        body: JSON.stringify({ orders }),
       });
-      if (!response.ok) throw new Error('Gagal memperbarui sticker');
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = typeof payload?.error === 'string' ? payload.error : 'Gagal memperbarui urutan sticker';
+        throw new Error(message);
+      }
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['album', albumId, 'stickers'] });
-      showToast({ title: 'Sticker diperbarui', variant: 'success' });
+      queryClient.invalidateQueries({ queryKey: ['album', albumId, STICKER_QUERY_KEY] });
+      showToast({ title: 'Urutan sticker diperbarui', variant: 'success' });
     },
-    onError: (error: unknown) => {
-      showToast({ title: 'Gagal', description: (error as Error).message, variant: 'destructive' });
-    }
+    onError: (err) => {
+      showToast({ title: 'Gagal memperbarui urutan', description: err.message, variant: 'destructive' });
+    },
   });
 
-  const toggleSelection = (id: string) => {
-    setSelected((prev) => (prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]));
-  };
+  const deleteMutation = useMutation<{ ok: true }, Error, string[]>({
+    mutationFn: async (ids) => {
+      const response = await fetch(`/api/albums/${albumId}/stickers`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = typeof payload?.error === 'string' ? payload.error : 'Gagal menghapus sticker';
+        throw new Error(message);
+      }
+      return response.json();
+    },
+    onSuccess: (_data, variables) => {
+      setSelected((prev) => prev.filter((id) => !variables.includes(id)));
+      queryClient.invalidateQueries({ queryKey: ['album', albumId, STICKER_QUERY_KEY] });
+      showToast({ title: 'Sticker dihapus', variant: 'success' });
+    },
+    onError: (err) => {
+      showToast({ title: 'Gagal menghapus sticker', description: err.message, variant: 'destructive' });
+    },
+  });
 
-  if (isLoading) {
-    return <p className="text-sm text-muted-foreground">Memuat sticker...</p>;
+  const isBusy = reorderMutation.isPending || deleteMutation.isPending;
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
+  }, []);
+
+  const handleMove = useCallback(
+    (id: string, direction: 'up' | 'down') => {
+      if (isBusy) {
+        return;
+      }
+      const index = stickers.findIndex((sticker) => sticker.id === id);
+      if (index === -1) {
+        return;
+      }
+      const swapIndex = direction === 'up' ? index - 1 : index + 1;
+      if (swapIndex < 0 || swapIndex >= stickers.length) {
+        return;
+      }
+
+      const reordered = [...stickers];
+      [reordered[index], reordered[swapIndex]] = [reordered[swapIndex], reordered[index]];
+      const orders = reordered.map((sticker, orderIndex) => ({ id: sticker.id, sort_index: orderIndex }));
+      reorderMutation.mutate({ orders });
+    },
+    [isBusy, reorderMutation, stickers],
+  );
+
+  const handleDelete = useCallback(
+    (ids: string[]) => {
+      if (ids.length === 0 || isBusy) {
+        return;
+      }
+      deleteMutation.mutate(ids);
+    },
+    [deleteMutation, isBusy],
+  );
+
+  const handleClearSelection = useCallback(() => {
+    setSelected([]);
+  }, []);
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-3xl border border-destructive/40 bg-destructive/5 p-6 text-sm text-destructive">
+          {error.message}
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Coba lagi
+        </Button>
+      </div>
+    );
   }
 
-  const stickers = data?.data ?? [];
+  const total = stickers.length;
 
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">{stickers.length} sticker</p>
-        {selected.length > 0 && (
-          <Badge className="bg-primary/10 text-primary">{selected.length} dipilih</Badge>
-        )}
-      </div>
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-6">
-        {stickers.map((sticker: any) => (
-          <div
-            key={sticker.id}
-            className={`group relative overflow-hidden rounded-3xl border border-border p-2 transition ${
-              selected.includes(sticker.id) ? 'ring-2 ring-primary' : 'hover:border-primary'
-            }`}
-          >
-            <button
-              onClick={() => toggleSelection(sticker.id)}
-              className="absolute left-2 top-2 rounded-full bg-background/80 px-2 py-1 text-xs"
-            >
-              {selected.includes(sticker.id) ? 'Dipilih' : 'Pilih'}
-            </button>
-            <div className="relative h-32 w-full overflow-hidden rounded-2xl bg-muted">
-              <Image src={sticker.thumb_url ?? sticker.file_url} alt={sticker.title ?? 'Sticker'} fill className="object-cover" />
-            </div>
-            <div className="mt-3 space-y-2 text-sm">
-              <Input
-                defaultValue={sticker.title ?? ''}
-                placeholder="Nama sticker"
-                onBlur={(event) =>
-                  updateSticker.mutate({ id: sticker.id, title: event.target.value || undefined })
-                }
-              />
-              <Input
-                defaultValue={sticker.tags?.join(', ') ?? ''}
-                placeholder="Tag (pisahkan koma)"
-                onBlur={(event) =>
-                  updateSticker.mutate({
-                    id: sticker.id,
-                    tags: event.target.value
-                      .split(',')
-                      .map((tag) => tag.trim())
-                      .filter(Boolean)
-                  })
-                }
-              />
-              <p className="text-xs text-muted-foreground">{sticker.width}x{sticker.height}px · {sticker.size_kb}KB</p>
-            </div>
+  let content: React.ReactNode;
+
+  if (isLoading) {
+    content = (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div key={index} className="space-y-3 rounded-3xl border border-border bg-card p-4 shadow-sm">
+            <Skeleton className="aspect-square w-full rounded-2xl" />
+            <Skeleton className="h-4 w-2/3" />
           </div>
         ))}
       </div>
+    );
+  } else if (total === 0) {
+    content = (
+      <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-border bg-card/60 p-10 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+          <ImageOff className="h-7 w-7 text-muted-foreground" />
+        </div>
+        <p className="mt-4 text-base font-semibold text-foreground">Belum ada sticker</p>
+        <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+          Unggah sticker pertamamu melalui dropzone di atas untuk mulai membangun koleksi ini.
+        </p>
+      </div>
+    );
+  } else {
+    content = (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+        {stickers.map((sticker) => (
+          <StickerCard
+            key={sticker.id}
+            id={sticker.id}
+            thumbUrl={sticker.thumb_url ?? sticker.file_url}
+            title={sticker.title}
+            selected={selected.includes(sticker.id)}
+            onSelectToggle={() => toggleSelect(sticker.id)}
+            onMoveUp={() => handleMove(sticker.id, 'up')}
+            onMoveDown={() => handleMove(sticker.id, 'down')}
+            onDelete={() => handleDelete([sticker.id])}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {selected.length > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border bg-card/80 p-3 backdrop-blur">
+          <p className="text-sm font-medium text-foreground">
+            {selected.length} sticker dipilih
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => handleDelete(selected)}
+              disabled={isBusy}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Hapus dipilih
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={handleClearSelection} disabled={isBusy}>
+              Batal
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {formatCount(total)} sticker
+          {isFetching && !isLoading ? ' · menyegarkan…' : ''}
+        </p>
+        <Button type="button" size="sm" variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Muat ulang
+        </Button>
+      </div>
+
+      {content}
     </div>
   );
 }
+
+export default StickerGrid;

--- a/components/Toaster.tsx
+++ b/components/Toaster.tsx
@@ -1,32 +1,9 @@
 'use client';
-import * as React from 'react';
-import { useToast } from '@/hooks/useToast';
 
-type Variant = 'default' | 'success' | 'destructive';
-const variantClass: Record<Variant, string> = {
-  default: 'bg-foreground text-background',
-  success: 'bg-emerald-600 text-white',
-  destructive: 'bg-red-600 text-white',
-};
+import { Toaster as ShadcnToaster } from '@/components/ui/toaster';
 
 export function Toaster() {
-  const { toasts, dismissToast } = useToast();
-  if (!toasts?.length) return null;
-
-  return (
-    <div className="fixed bottom-4 right-4 z-50 flex w-80 max-w-[90vw] flex-col gap-2">
-      {toasts.map((t) => (
-        <div key={t.id} className={`rounded-2xl px-4 py-3 shadow-lg ${variantClass[(t.variant ?? 'default') as Variant]}`}>
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              {t.title && <p className="font-semibold leading-snug">{t.title}</p>}
-              {t.description && <p className="mt-0.5 break-words text-sm opacity-90">{t.description}</p>}
-            </div>
-            <button onClick={() => dismissToast(t.id)} className="shrink-0 rounded-md/50 px-2 text-sm/none opacity-80 hover:opacity-100" aria-label="Tutup">×</button>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+  return <ShadcnToaster />;
 }
+
 export default Toaster;

--- a/components/UploadDropzone.tsx
+++ b/components/UploadDropzone.tsx
@@ -3,14 +3,74 @@
 import { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { UploadCloud } from 'lucide-react';
-import { Button } from './ui/button';
-import { Progress } from './ui/progress';
-import { useUploadQueue } from '@/hooks/useUploadQueue';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { useUploadQueue } from '@/hooks/useUploadQueue';
 import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/utils';
 
 interface UploadDropzoneProps {
   albumId: string;
+}
+
+type UploadPayload = { id: string; file: File };
+
+type UploadResponse = unknown;
+
+const ACCEPTED_TYPES: Record<string, string[]> = {
+  'image/png': ['.png'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'image/webp': ['.webp'],
+};
+
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
+
+function uploadWithProgress(
+  url: string,
+  files: UploadPayload[],
+  onProgress: (percent: number) => void,
+): Promise<UploadResponse> {
+  const formData = new FormData();
+  files.forEach(({ file }) => {
+    formData.append('files', file, file.name);
+  });
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+    xhr.withCredentials = true;
+    xhr.responseType = 'json';
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        const percent = Math.min(100, Math.round((event.loaded / event.total) * 100));
+        onProgress(percent);
+      } else {
+        onProgress(50);
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(xhr.response ?? {});
+        return;
+      }
+
+      const message =
+        (xhr.response && typeof xhr.response === 'object' && 'error' in xhr.response
+          ? (xhr.response as { error?: string }).error
+          : undefined) ?? xhr.statusText ?? 'Upload gagal';
+      reject(new Error(message));
+    };
+
+    xhr.onerror = () => {
+      reject(new Error('Tidak dapat mengunggah file.'));
+    };
+
+    xhr.send(formData);
+  });
 }
 
 export function UploadDropzone({ albumId }: UploadDropzoneProps) {
@@ -18,84 +78,103 @@ export function UploadDropzone({ albumId }: UploadDropzoneProps) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
 
-  const mutation = useMutation({
-    mutationFn: async (files: { id: string; file: File }[]) => {
-      const formData = new FormData();
-      files.forEach(({ file }) => formData.append('files', file));
-      const response = await fetch(`/api/albums/${albumId}/stickers`, {
-        method: 'POST',
-        body: formData
+  const mutation = useMutation<UploadResponse, Error, UploadPayload[]>({
+    mutationFn: async (payload) => {
+      payload.forEach(({ id }) => {
+        updateItem(id, { status: 'uploading', progress: 5, error: undefined });
       });
-      if (!response.ok) throw new Error('Gagal mengunggah sticker');
-      return response.json();
+
+      const result = await uploadWithProgress(`/api/albums/${albumId}/stickers`, payload, (percent) => {
+        payload.forEach(({ id }) => {
+          updateItem(id, { progress: Math.max(percent, 5), status: 'uploading' });
+        });
+      });
+
+      payload.forEach(({ id }) => {
+        updateItem(id, { status: 'success', progress: 100 });
+        setTimeout(() => {
+          clearItem(id);
+        }, 1500);
+      });
+
+      return result;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['album', albumId, 'stickers'] });
-      showToast({ title: 'Upload berhasil', variant: 'success' });
+      showToast({ title: 'Sticker berhasil diunggah', variant: 'success' });
     },
-    onError: (error: unknown) => {
-      showToast({ title: 'Upload gagal', description: (error as Error).message, variant: 'destructive' });
-    }
+    onError: (error, variables) => {
+      const message = error.message || 'Gagal mengunggah sticker';
+      variables?.forEach(({ id }) => {
+        updateItem(id, { status: 'error', progress: 0, error: message });
+      });
+      showToast({ title: 'Upload gagal', description: message, variant: 'destructive' });
+    },
   });
 
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
-      const payload = acceptedFiles.map((file) => {
-        const id = addFile(file);
-        updateItem(id, { status: 'uploading', progress: 5 });
-        return { id, file };
-      });
-      mutation.mutate(payload, {
-        onSuccess: () => {
-          payload.forEach(({ id }) => {
-            updateItem(id, { status: 'success', progress: 100 });
-            setTimeout(() => clearItem(id), 1500);
-          });
-        },
-        onError: () => {
-          payload.forEach(({ id }) => updateItem(id, { status: 'error', progress: 0 }));
-        }
-      });
+      if (acceptedFiles.length === 0) {
+        return;
+      }
+
+      const payload = acceptedFiles.map((file) => ({ id: addFile(file), file }));
+      mutation.mutate(payload);
     },
-    [addFile, clearItem, mutation, updateItem]
+    [addFile, mutation],
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    accept: {
-      'image/png': ['.png'],
-      'image/jpeg': ['.jpg', '.jpeg'],
-      'image/webp': ['.webp']
+    accept: ACCEPTED_TYPES,
+    multiple: true,
+    maxSize: MAX_FILE_SIZE_BYTES,
+    onDropRejected: (rejections) => {
+      rejections.forEach((rejection) => {
+        const message = rejection.errors.map((error) => error.message).join(', ');
+        showToast({
+          title: rejection.file.name,
+          description: message || 'File tidak dapat diunggah',
+          variant: 'destructive',
+        });
+      });
     },
-    multiple: true
   });
+
+  const isUploading = mutation.isPending;
 
   return (
     <div className="space-y-4">
       <div
         {...getRootProps()}
-        className={`flex cursor-pointer flex-col items-center justify-center rounded-3xl border-2 border-dashed p-8 text-center transition ${
-          isDragActive ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/70'
-        }`}
+        className={cn(
+          'flex cursor-pointer flex-col items-center justify-center rounded-3xl border-2 border-dashed bg-card p-8 text-center transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+          isDragActive ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/70',
+          isUploading && 'pointer-events-none opacity-70',
+        )}
       >
-        <input {...getInputProps()} />
+        <input {...getInputProps()} disabled={isUploading} />
         <UploadCloud className="h-10 w-10 text-primary" />
         <p className="mt-4 text-sm text-muted-foreground">
-          Tarik & letakkan gambar (PNG/JPG/WEBP) atau klik untuk memilih.
+          Tarik & jatuhkan gambar (PNG, JPG, WEBP) atau klik untuk memilih file.
         </p>
-        <Button type="button" variant="secondary" className="mt-4">
+        <Button type="button" variant="secondary" className="mt-4" disabled={isUploading}>
           Pilih File
         </Button>
       </div>
+
       {items.length > 0 && (
         <div className="space-y-2">
           {items.map((item) => (
-            <div key={item.id} className="rounded-2xl border border-border p-3">
+            <div key={item.id} className="rounded-2xl border border-border bg-card p-3 shadow-sm">
               <div className="flex items-center justify-between text-sm">
-                <span className="font-medium">{item.file.name}</span>
-                <span className="text-xs text-muted-foreground">{item.status}</span>
+                <span className="truncate font-medium">{item.file.name}</span>
+                <span className="text-xs capitalize text-muted-foreground">{item.status}</span>
               </div>
-              <Progress value={item.progress} />
+              <div className="mt-2">
+                <Progress value={item.progress} />
+              </div>
+              {item.error && <p className="mt-2 text-xs text-destructive">{item.error}</p>}
             </div>
           ))}
         </div>

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,9 +1,16 @@
-export function slugify(input: string) {
+const TRIM_HYPHENS_REGEX = /(^-+|-+$)/g;
+const NON_ALPHANUMERIC_REGEX = /[^a-z0-9-]/g;
+const SEPARATOR_REGEX = /[\s_]+/g;
+const COLLAPSE_HYPHENS_REGEX = /-{2,}/g;
+
+export function slugify(input: string): string {
   return input
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
     .toLowerCase()
     .trim()
-    .replace(/[\s_]+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
+    .replace(SEPARATOR_REGEX, '-')
+    .replace(NON_ALPHANUMERIC_REGEX, '')
+    .replace(COLLAPSE_HYPHENS_REGEX, '-')
+    .replace(TRIM_HYPHENS_REGEX, '');
 }

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,22 +1,55 @@
 import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/ssr';
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
 
-export function getSupabaseServerClient() {
+import type { Database } from '@/types/database';
+
+export type SupabaseServerClient = SupabaseClient<Database>;
+
+export function getServerClient(): SupabaseServerClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase environment variables are not configured.');
+  }
+
   const cookieStore = cookies();
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-  return createServerClient(url, anon, {
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       get(name: string) {
         return cookieStore.get(name)?.value;
       },
-      set(name: string, value: string, options: any) {
-        try { cookieStore.set({ name, value, ...options }); } catch {}
+      set(name: string, value: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value, ...options });
+        } catch {
+          // ignored because the cookie store can be read-only during SSR
+        }
       },
-      remove(name: string, options: any) {
-        try { cookieStore.set({ name, value: '', ...options, maxAge: 0 }); } catch {}
+      remove(name: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value: '', ...options, maxAge: 0 });
+        } catch {
+          // ignored because the cookie store can be read-only during SSR
+        }
       },
     },
   });
+}
+
+export async function getServerUser(): Promise<{ user: User | null }> {
+  const supabase = getServerClient();
+  const { data, error } = await supabase.auth.getUser();
+
+  if (error) {
+    if (error.status === 401) {
+      return { user: null };
+    }
+
+    throw error;
+  }
+
+  return { user: data.user ?? null };
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,43 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-export function cn(...inputs: ClassValue[]) { return twMerge(clsx(inputs)); }
+
+export function cn(...classes: ClassValue[]): string {
+  return twMerge(clsx(...classes));
+}
+
+const COUNT_UNITS = [
+  { value: 1_000_000_000, suffix: 'B' },
+  { value: 1_000_000, suffix: 'M' },
+  { value: 1_000, suffix: 'K' },
+] as const;
+
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) {
+    return '0';
+  }
+
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+
+  for (const unit of COUNT_UNITS) {
+    if (abs >= unit.value) {
+      const scaled = abs / unit.value;
+      const rounded = scaled >= 10 ? Math.round(scaled).toString() : scaled.toFixed(1).replace(/\.0$/, '');
+      return `${sign}${rounded}${unit.suffix}`;
+    }
+  }
+
+  if (abs >= 1) {
+    return `${sign}${abs.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+  }
+
+  return `${sign}${abs.toPrecision(1)}`;
+}
+
+export function assertOk<T>(value: T, message = 'Unexpected null or undefined value'): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,138 @@
+-- profiles (opsional untuk nama)
+create table if not exists profiles (
+  id uuid primary key references auth.users on delete cascade,
+  email text unique,
+  display_name text,
+  avatar_url text,
+  created_at timestamp with time zone default now()
+);
+
+-- albums
+create table if not exists albums (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  slug text unique not null,
+  cover_url text,
+  visibility text not null default 'private', -- 'public' | 'unlisted' | 'private'
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- album_collaborators (edit access)
+create table if not exists album_collaborators (
+  id uuid primary key default gen_random_uuid(),
+  album_id uuid not null references albums(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  unique(album_id, user_id)
+);
+
+-- stickers
+create table if not exists stickers (
+  id uuid primary key default gen_random_uuid(),
+  album_id uuid not null references albums(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  file_url text not null,
+  thumb_url text,
+  title text,
+  size_kb int,
+  sort_index int not null default 0,
+  created_at timestamp with time zone default now()
+);
+
+-- packs
+create table if not exists packs (
+  id uuid primary key default gen_random_uuid(),
+  album_id uuid not null references albums(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  author text,
+  exported_zip_url text,
+  public_url text,
+  wa_share_url text,
+  created_at timestamp with time zone default now()
+);
+
+-- pack_stickers (urutan sticker dalam pack)
+create table if not exists pack_stickers (
+  id uuid primary key default gen_random_uuid(),
+  pack_id uuid not null references packs(id) on delete cascade,
+  sticker_id uuid not null references stickers(id) on delete cascade,
+  ord int not null
+);
+
+-- indexes
+create index if not exists idx_albums_slug on albums(slug);
+create index if not exists idx_stickers_album on stickers(album_id);
+
+-- RLS
+alter table profiles enable row level security;
+alter table albums enable row level security;
+alter table album_collaborators enable row level security;
+alter table stickers enable row level security;
+alter table packs enable row level security;
+alter table pack_stickers enable row level security;
+
+-- policies (ringkas):
+-- profiles
+create policy "read own profile" on profiles for select using (auth.uid() = id);
+create policy "insert own profile" on profiles for insert with check (auth.uid() = id);
+create policy "update own profile" on profiles for update using (auth.uid() = id);
+
+-- albums
+create policy "read public or member" on albums for select using (
+  visibility in ('public','unlisted') or owner_id = auth.uid() or
+  exists(select 1 from album_collaborators c where c.album_id = albums.id and c.user_id = auth.uid())
+);
+create policy "insert own album" on albums for insert with check (owner_id = auth.uid());
+create policy "update own or collaborator" on albums for update using (
+  owner_id = auth.uid() or exists(select 1 from album_collaborators c where c.album_id = albums.id and c.user_id = auth.uid())
+);
+create policy "delete own album" on albums for delete using (owner_id = auth.uid());
+
+-- album_collaborators
+create policy "read collab if member" on album_collaborators for select using (
+  exists(select 1 from albums a where a.id = album_collaborators.album_id
+    and (a.owner_id = auth.uid() or exists(select 1 from album_collaborators c where c.album_id = a.id and c.user_id = auth.uid())))
+);
+create policy "manage collab owner only" on album_collaborators for all using (
+  exists(select 1 from albums a where a.id = album_collaborators.album_id and a.owner_id = auth.uid())
+) with check (
+  exists(select 1 from albums a where a.id = album_collaborators.album_id and a.owner_id = auth.uid())
+);
+
+-- stickers
+create policy "read stickers if can read album" on stickers for select using (
+  exists(select 1 from albums a where a.id = stickers.album_id and
+    (a.visibility in ('public','unlisted') or a.owner_id = auth.uid() or
+     exists(select 1 from album_collaborators c where c.album_id = a.id and c.user_id = auth.uid())))
+);
+create policy "insert stickers owner or collaborator" on stickers for insert with check (
+  owner_id = auth.uid() and
+  exists(select 1 from albums a where a.id = stickers.album_id and (a.owner_id = auth.uid()
+    or exists(select 1 from album_collaborators c where c.album_id = a.id and c.user_id = auth.uid())))
+);
+create policy "update/delete stickers owner or collaborator" on stickers for update using (
+  owner_id = auth.uid()
+) with check (owner_id = auth.uid());
+create policy "delete stickers owner or collaborator using album" on stickers for delete using (
+  exists(select 1 from albums a where a.id = stickers.album_id and (a.owner_id = auth.uid()
+    or exists(select 1 from album_collaborators c where c.album_id = a.id and c.user_id = auth.uid())))
+);
+
+-- packs
+create policy "read packs if can read album" on packs for select using (
+  exists(select 1 from albums a where a.id = packs.album_id and
+    (a.visibility in ('public','unlisted') or a.owner_id = auth.uid() or
+     exists(select 1 from album_collaborators c where c.album_id = a.id and c.user_id = auth.uid())))
+);
+create policy "insert/update/delete packs owner or collaborator" on packs for all using (
+  owner_id = auth.uid()
+) with check (owner_id = auth.uid());
+
+-- pack_stickers (owner album saja)
+create policy "manage pack_stickers owner" on pack_stickers for all using (
+  exists(select 1 from packs p where p.id = pack_stickers.pack_id and p.owner_id = auth.uid())
+) with check (
+  exists(select 1 from packs p where p.id = pack_stickers.pack_id and p.owner_id = auth.uid())
+);


### PR DESCRIPTION
## Summary
- add a typed Supabase server client helper with user retrieval
- extend shared utilities including slug, count formatting, and assertions
- refresh app-level providers with React Query, theming, and shadcn toaster
- add the Supabase schema file matching the database definition

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea64a345f0833182a5031608f80f49