### PR TITLE
Handle missing Supabase config gracefully

### DIFF
--- a/app/(auth)/auth/callback/AuthCallback.tsx
+++ b/app/(auth)/auth/callback/AuthCallback.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/useToast';
@@ -9,12 +9,23 @@ export default function AuthCallback() {
   const router = useRouter();
   const sp = useSearchParams();
   const { showToast } = useToast();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
     (async () => {
       const code = sp?.get?.('code') ?? '';
       if (!code) { router.replace('/login'); return; }
+
+      if (!supabase) {
+        showToast({
+          title: 'Konfigurasi belum lengkap',
+          description:
+            'Supabase belum terkonfigurasi. Hubungi administrator untuk melengkapi environment variable.',
+          variant: 'destructive',
+        });
+        router.replace('/login?error=magic-link');
+        return;
+      }
 
       try {
         // Kompatibel lintas versi supabase-js

--- a/app/(auth)/auth/callback/page.tsx
+++ b/app/(auth)/auth/callback/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/useToast';
@@ -9,7 +9,7 @@ import { useToast } from '@/hooks/useToast';
 function CallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -17,6 +17,17 @@ function CallbackInner() {
       // Pakai optional chaining supaya aman bagi TS
       const code = searchParams?.get('code') ?? '';
       if (!code) {
+        router.replace('/login');
+        return;
+      }
+
+      if (!supabase) {
+        showToast({
+          title: 'Konfigurasi belum lengkap',
+          description:
+            'Supabase belum terkonfigurasi. Hubungi administrator untuk melengkapi environment variable.',
+          variant: 'destructive',
+        });
         router.replace('/login');
         return;
       }

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -7,14 +7,7 @@ import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/useToast';
 
 export default function LoginForm() {
-  const supabase = useMemo(() => {
-    try {
-      return createClient();
-    } catch (error) {
-      console.error('Supabase client is not configured.', error);
-      return null;
-    }
-  }, []);
+  const supabase = useMemo(() => createClient(), []);
   const { showToast } = useToast();
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -3,25 +3,29 @@
 
 import { createBrowserClient } from '@supabase/ssr';
 
-export function createClient() {
+export type SupabaseBrowserClient = ReturnType<typeof createBrowserClient>;
+
+export function createClient(): SupabaseBrowserClient | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !anon) {
-    throw new Error('Supabase client credentials are not configured.');
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        'Supabase client credentials are not configured. Set NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY untuk mengaktifkan fitur login.'
+      );
+    }
+    return null;
   }
 
   return createBrowserClient(url, anon, {
     auth: {
-      flowType: 'pkce',          // penting untuk PKCE
+      flowType: 'pkce', // penting untuk PKCE
       persistSession: true,
       autoRefreshToken: true,
       detectSessionInUrl: false, // karena kita tukar code manual di /auth/callback
     },
   });
 }
-
-// (opsional) kalau butuh tipe:
-export type SupabaseBrowserClient = ReturnType<typeof createClient>;
 
 export default createClient;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -3,3 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,18 +18,30 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "**/*.cjs",
-    "**/*.mjs"
+    "**/*.mjs",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- return `null` from the Supabase browser client factory when credentials are missing instead of throwing
- guard login and auth callback flows so they show a helpful toast and redirect when Supabase is not configured
- update Next.js TypeScript config metadata after running the linter

## Testing
- npm run typecheck
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eaa0037fac8331abb7e4c66eb0ba46