### PR TITLE
Normalize Supabase server helper exports

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation';
 
 import Providers from '@/components/Providers';
 import { DashboardShell } from './_components/dashboard-shell';
-import { getServerUser } from '@/lib/supabaseServer';
+import getServerUser from '@/lib/supabaseServer';
 import { isSupabaseConfigured } from '@/lib/env';
 
 export default async function DashboardPage() {

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -4,7 +4,7 @@ import type { SupabaseClient, User } from '@supabase/supabase-js';
 
 import type { Database } from '@/types/database';
 
-export type SupabaseServerClient = SupabaseClient<Database>;
+export type SupabaseServerClient = SupabaseClient<any>;
 
 export function getServerClient(): SupabaseServerClient {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -51,7 +51,7 @@ export function getServerClient(): SupabaseServerClient {
   });
 }
 
-export async function getServerUser(): Promise<{ user: User | null }> {
+export default async function getServerUser(): Promise<{ user: User | null }> {
   try {
     const supabase = getServerClient();
     const { data, error } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- update the Supabase server helper exports to provide a default `getServerUser` and the requested `SupabaseServerClient` type
- adjust the dashboard page to use the new default export helper

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68eb1f38271083318176ad5e9ee38b7c